### PR TITLE
fix path name problems for Windows users

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -1,5 +1,5 @@
 phantom_run <- function(args, wait = TRUE) {
-  phantom_bin <- Sys.which("phantomjs")
+  phantom_bin <- find_phantom()
   if (phantom_bin == "")
     stop("phantomjs not found in path. phantomjs must be installed and in path.")
 
@@ -8,6 +8,24 @@ phantom_run <- function(args, wait = TRUE) {
 
   system2(phantom_bin, args = args, wait = wait)
 }
+
+
+# Try really hard to find bower in Windows
+find_phantom <- function(){
+  # a slightly more robust finder of bower for windows
+  # which does not require PATH environment variable to be set
+  phantom_path = if(Sys.which("phantomjs") == "") {
+    # if it does not find Sys.which('bower')
+    # also check APPDATA to see if found there
+    if(identical(.Platform$OS.type,"windows")) {
+      Sys.which(file.path(Sys.getenv("APPDATA"),"npm","phantomjs."))
+    }
+  } else {
+    Sys.which("phantomjs")
+  }
+  return(phantom_path)
+}
+
 
 # Given a vector or list, drop all the NULL items in it
 dropNulls <- function(x) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -11,19 +11,20 @@ phantom_run <- function(args, wait = TRUE) {
 
 
 # Try really hard to find bower in Windows
-find_phantom <- function(){
+find_phantom <- function() {
   # a slightly more robust finder of bower for windows
   # which does not require PATH environment variable to be set
-  phantom_path = if(Sys.which("phantomjs") == "") {
+  phantom_path <-  if (Sys.which( "phantomjs" ) == "") {
     # if it does not find Sys.which('bower')
     # also check APPDATA to see if found there
-    if(identical(.Platform$OS.type,"windows")) {
-      Sys.which(file.path(Sys.getenv("APPDATA"),"npm","phantomjs."))
+    if( identical(.Platform$OS.type, "windows") ) {
+      Sys.which( file.path(Sys.getenv("APPDATA"), "npm", "phantomjs.cmd") )
     }
   } else {
-    Sys.which("phantomjs")
+    Sys.which( "phantomjs" )
   }
-  return(phantom_path)
+
+  phantom_path
 }
 
 

--- a/R/webshot.R
+++ b/R/webshot.R
@@ -125,7 +125,7 @@ webshot <- function(
   }
 
   args <- dropNulls(list(
-    system.file("webshot.js", package = "webshot"),
+    paste0("'",system.file("webshot.js", package = "webshot"),"'"),
     url,
     file,
     paste0("--vwidth=", vwidth),


### PR DESCRIPTION
This pull attempts to correct two problems in order of seriousness with `webshot` on Windows.

1.  `system.file("webshot.js", package = "webshot")` on Windows will probably return something like `C:\Program Files\...`.  The space in the path supplied to `args` will cause an error.  My solution was to enclose the path with `'`, but I'm not sure what effect this has on other non-Windows OS.
2.  As mentioned in #8, the second change is more a convenience change for the poor ignorant :) Windows user.  If a Windows user installs `node`, the `PATH` is not automatically set.  The Windows user can still use `node` if they use the `cmd.exe` from the shortcut in `node`.  A `find_phantom` function looks in the typical path for globally installed `node` modules in addition to `PATH`.