### PR TITLE
enclose webshot path by shQuote() for Windows

### DIFF
--- a/R/webshot.R
+++ b/R/webshot.R
@@ -125,7 +125,7 @@ webshot <- function(
   }
 
   args <- dropNulls(list(
-    paste0("'",system.file("webshot.js", package = "webshot"),"'"),
+    shQuote(system.file("webshot.js", package = "webshot")),
     url,
     file,
     paste0("--vwidth=", vwidth),


### PR DESCRIPTION
The webshot() can't run on my Windows PC.

```
> webshot("http://www.rstudio.com", "rstudio.png")
Can't open ''C:/Users/hoxo.m/Documents/R/win-library/3.1/webshot/webshot.js''
Error in webshot("http://www.rstudio.com", "rstudio.png") : 
  webshot.js returned failure value: 65535
In addition: Warning message:
running command '"C:\PROGRA~3\CHOCOL~1\bin\PHANTO~1.EXE" 'C:/Users/hoxo.m/Documents/R/win-library/3.1/webshot/webshot.js' http://www.rstudio.com rstudio.png --vwidth=992 --vheight=744 --delay=0.2' had status 65535 
```

The cause is that the webshot path is enclosed by ''.
Commit  https://github.com/wch/webshot/commit/9a7158ca0b8420bc673db026cdd5073ba589e5da enclosed webshot path in '', but that does not work on my Windows PC.

Using "" instead of '' solved that problem.
For Linux, `shQuote()` works to enclose the path in ''.
For Windows, `shQuote()` works to enclose the path in "".

Therefore, I think you should change
```r
paste0("'", system.file("webshot.js", package = "webshot"), "'")
```
to
```r
shQuote(system.file("webshot.js", package = "webshot")
```

That works well on my Windows PC.
Please check on that.

```
> sessionInfo()
R version 3.1.3 (2015-03-09)
Platform: x86_64-w64-mingw32/x64 (64-bit)
Running under: Windows 8 x64 (build 9200)

locale:
[1] LC_COLLATE=Japanese_Japan.932  LC_CTYPE=Japanese_Japan.932   
[3] LC_MONETARY=Japanese_Japan.932 LC_NUMERIC=C                  
[5] LC_TIME=Japanese_Japan.932    

attached base packages:
[1] stats     graphics  grDevices utils     datasets  methods   base     

other attached packages:
[1] webshot_0.2

loaded via a namespace (and not attached):
[1] magrittr_1.5 tools_3.1.3 
```