### PR TITLE
Vectorize arguments of webshot

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,13 +4,15 @@ Version: 0.3.2.9000
 Authors@R: c(
     person("Winston", "Chang", email = "winston@rstudio.com", role = c("aut", "cre")),
     person("Yihui", "Xie", role = "ctb"),
+    person("Francois", "Guillem", role = "ctb"),
     person("Nicolas", "Perriault", role = "ctb", comment = "The CasperJS library")
     )
 Description: Takes screenshots of web pages, including Shiny applications.
 Depends:
     R (>= 3.0)
 Imports:
-    magrittr
+    magrittr,
+    jsonlite
 Suggests:
     httpuv,
     knitr,

--- a/R/appshot.R
+++ b/R/appshot.R
@@ -2,8 +2,6 @@
 #'
 #' @inheritParams webshot
 #' @param app A Shiny app object, or a string naming an app directory.
-#' @param file Name of output file. Should end with \code{.png}, \code{.pdf}, or
-#' \code{.jpeg}.
 #' @param port Port that Shiny will listen on.
 #' @param envvars A named character vector or named list of environment
 #'   variables and values to set for the Shiny app's R process. These will be

--- a/R/appshot.R
+++ b/R/appshot.R
@@ -2,6 +2,8 @@
 #'
 #' @inheritParams webshot
 #' @param app A Shiny app object, or a string naming an app directory.
+#' @param file Name of output file. Should end with \code{.png}, \code{.pdf}, or
+#' \code{.jpeg}.
 #' @param port Port that Shiny will listen on.
 #' @param envvars A named character vector or named list of environment
 #'   variables and values to set for the Shiny app's R process. These will be

--- a/R/image.R
+++ b/R/image.R
@@ -4,10 +4,12 @@
 #' appearance -- it is lossless compression. This requires GraphicsMagick
 #' (recommended) or ImageMagick to be installed.
 #'
-#' @param filename Name of image to resize.
+#' @param filename Character vector containing the path of images to resize.
 #' @param geometry Scaling specification. Can be a percent, as in \code{"50\%"},
 #'   or pixel dimensions like \code{"120x120"}, \code{"120x"}, or \code{"x120"}.
-#'   Any valid ImageMagick geometry specifation can be used.
+#'   Any valid ImageMagick geometry specifation can be used. If \code{filename}
+#'   contains multiple images, this can be a vector to specify distinct sizes
+#'   for each image.
 #'
 #' @examples
 #' if (interactive()) {
@@ -73,7 +75,8 @@ resize_one <- function(filename, geometry) {
 #' the last step. Otherwise, if the resizing happens after file shrinking, it
 #' will be as if the shrinking didn't happen at all.
 #'
-#' @param filename Name of image to shrink. Must be a PNG file.
+#' @param filename Character vector containing the path of images to resize.
+#'   Must be PNG files.
 #'
 #' @examples
 #' if (interactive()) {

--- a/R/image.R
+++ b/R/image.R
@@ -21,11 +21,12 @@
 #' }
 #' @export
 resize <- function(filename, geometry) {
-  mapply(.resize, filename = filename, geometry = geometry)
+  mapply(resize_one, filename = filename, geometry = geometry,
+         SIMPLIFY = FALSE, USE.NAMES = FALSE)
   structure(filename, class = "webshot")
 }
 
-.resize <- function(filename, geometry) {
+resize_one <- function(filename, geometry) {
   # Handle missing phantomjs
   if (is.null(filename)) return(NULL)
 
@@ -81,11 +82,11 @@ resize <- function(filename, geometry) {
 #' }
 #' @export
 shrink <- function(filename) {
-  mapply(.shrink, filename = filename)
+  mapply(shrink_one, filename = filename, SIMPLIFY = FALSE, USE.NAMES = FALSE)
   structure(filename, class = "webshot")
 }
 
-.shrink <- function(filename) {
+shrink_one <- function(filename) {
   # Handle missing phantomjs
   if (is.null(filename)) return(NULL)
 

--- a/R/image.R
+++ b/R/image.R
@@ -21,6 +21,11 @@
 #' }
 #' @export
 resize <- function(filename, geometry) {
+  mapply(.resize, filename = filename, geometry = geometry)
+  structure(filename, class = "webshot")
+}
+
+.resize <- function(filename, geometry) {
   # Handle missing phantomjs
   if (is.null(filename)) return(NULL)
 
@@ -54,9 +59,8 @@ resize <- function(filename, geometry) {
   if (res != 0)
     stop ("Resizing with `gm convert`, `magick convert` or `convert` failed.")
 
-  structure(filename, class = "webshot")
+  filename
 }
-
 
 #' Shrink file size of a PNG
 #'
@@ -77,6 +81,11 @@ resize <- function(filename, geometry) {
 #' }
 #' @export
 shrink <- function(filename) {
+  mapply(.shrink, filename = filename)
+  structure(filename, class = "webshot")
+}
+
+.shrink <- function(filename) {
   # Handle missing phantomjs
   if (is.null(filename)) return(NULL)
 
@@ -89,5 +98,5 @@ shrink <- function(filename) {
   if (res != 0)
     stop ("Shrinking with `optipng` failed.")
 
-  structure(filename, class = "webshot")
+  filename
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -248,11 +248,8 @@ fix_windows_url <- function(url) {
 
   # If it's a "c:/path/file.html" path, or contains any backslashs, like
   # "c:\path", "\\path\\file.html", or "/path\\file.html", we need to fix it up.
-  if (grepl("^[a-zA-Z]:/", url) || grepl("\\", url, fixed = TRUE)) {
-    paste0("file:///", normalizePath(url, winslash = "/"))
-  } else {
-    url
-  }
+  needFix <- grepl("^[a-zA-Z]:/", url) | grepl("\\", url, fixed = TRUE)
+  ifelse(needFix, paste0("file:///", normalizePath(url, winslash = "/")), url)
 }
 
 

--- a/R/webshot.R
+++ b/R/webshot.R
@@ -2,7 +2,9 @@
 #'
 #' @param url A vector of URLs to visit.
 #' @param file A vector of names of output files. Should end with \code{.png},
-#'   \code{.pdf}, or \code{.jpeg}.
+#'   \code{.pdf}, or \code{.jpeg}. If several screenshots have to be taken and
+#'   only one filename is provided, then the function appends the index number
+#'   of the screenshot to the file name.
 #' @param vwidth Viewport width. This is the width of the browser "window".
 #' @param vheight Viewport height This is the height of the browser "window".
 #' @param cliprect Clipping rectangle. If \code{cliprect} and \code{selector}
@@ -185,7 +187,7 @@ webshot <- function(
   }
 
   # Create the table that contains all options for each screenshot
-  opts <- data.frame(url = url, file = file, vwidth = vwidth, vheight = vheight)
+  optsList <- data.frame(url = url, file = file, vwidth = vwidth, vheight = vheight)
 
   # Params selector, cliprect and expand can be either a vector that need to be
   # concatenated or a list of such vectors. This function can be used to convert
@@ -197,17 +199,17 @@ webshot <- function(
     })
   }
 
-  if (!is.null(cliprect)) opts$cliprect <- argToVec(cliprect)
-  if (!is.null(selector)) opts$selector <- argToVec(selector)
-  if (!is.null(expand)) opts$expand <- argToVec(expand)
-  if (!is.null(delay)) opts$delay <- delay
-  if (!is.null(zoom)) opts$zoom <- zoom
-  if (!is.null(eval)) opts$eval <- eval
+  if (!is.null(cliprect)) optsList$cliprect <- argToVec(cliprect)
+  if (!is.null(selector)) optsList$selector <- argToVec(selector)
+  if (!is.null(expand)) optsList$expand <- argToVec(expand)
+  if (!is.null(delay)) optsList$delay <- delay
+  if (!is.null(zoom)) optsList$zoom <- zoom
+  if (!is.null(eval)) optsList$eval <- eval
 
-  args <- dropNulls(list(
+  args <- list(
     shQuote(system.file("webshot.js", package = "webshot")),
-    shQuote(jsonlite::toJSON(opts))
-  ))
+    shQuote(jsonlite::toJSON(optsList))
+  )
 
   res <- phantom_run(args)
 

--- a/R/webshot.R
+++ b/R/webshot.R
@@ -57,7 +57,7 @@
 #' webshot("http://rstudio.github.io/leaflet", delay = 0.5)
 #'
 #' # One can also take screenshots of several URLs with only one command.
-#' # This is more efficient than calling multiple times 'webshot'.
+#' # This is more efficient than calling 'webshot' multiple times.
 #' webshot(c("https://github.com/rstudio/shiny",
 #'           "http://rstudio.github.io/leaflet"),
 #'         delay = 0.5)
@@ -135,14 +135,26 @@ webshot <- function(
   if(!is.null(expand) && !is.list(expand)) expand <- list(expand)
 
   # Check length of arguments
-  lengthOfArgs <- vapply(environment(), length, numeric(1))
-  maxLength <- max(lengthOfArgs)
-  if (any(! lengthOfArgs %in% c(0, 1, maxLength))) {
+  arg_list <- list(
+    url = url,
+    file = file,
+    vwidth = vwidth,
+    vheight = vheight,
+    cliprect = cliprect,
+    selector = selector,
+    expand = expand,
+    delay = delay,
+    zoom = zoom,
+    eval = eval
+  )
+  arg_length <- vapply(arg_list, length, numeric(1))
+  max_arg_length <- max(arg_length)
+  if (any(! arg_length %in% c(0, 1, max_arg_length))) {
     stop("All arguments should have same length or be single elements or NULL")
   }
 
   # If url is of length one replicate it to match the maximal length of arguments
-  if (length(url) < maxLength) url <- rep(url, maxLength)
+  if (length(url) < max_arg_length) url <- rep(url, max_arg_length)
 
   # If user provides only one file name but wants several screenshots, then the
   # below code generates as many file names as URLs following the pattern

--- a/R/webshot.R
+++ b/R/webshot.R
@@ -1,8 +1,8 @@
 #' Take a screenshot of a URL
 #'
-#' @param url A URL to visit.
-#' @param file Name of output file. Should end with \code{.png}, \code{.pdf}, or
-#'   \code{.jpeg}.
+#' @param url A vector of URLs to visit.
+#' @param file A Vector of names of output files. Should end with \code{.png},
+#' \code{.pdf}, or \code{.jpeg}.
 #' @param vwidth Viewport width. This is the width of the browser "window".
 #' @param vheight Viewport height This is the height of the browser "window".
 #' @param cliprect Clipping rectangle. If \code{cliprect} and \code{selector}
@@ -14,13 +14,19 @@
 #' @param selector One or more CSS selectors specifying a DOM element to set the
 #'   clipping rectangle to. The screenshot will contain these DOM elements. For
 #'   a given selector, if it has more than one match, only the first one will be
-#'   used. This option is not compatible with \code{cliprect}.
+#'   used. This option is not compatible with \code{cliprect}. When
+#'   taking screenshots of multiple URLs, this parameter can also be a list with
+#'   same length as \code{url} with each element of the list containing a vector
+#'   of CSS selectors to use for the corresponding URL.
 #' @param delay Time to wait before taking screenshot, in seconds. Sometimes a
 #'   longer delay is needed for all assets to display properly.
 #' @param expand A numeric vector specifying how many pixels to expand the
 #'   clipping rectangle by. If one number, the rectangle will be expanded by
 #'   that many pixels on all sides. If four numbers, they specify the top,
-#'   right, bottom, and left, in that order.
+#'   right, bottom, and left, in that order. When taking screenshots of multiple
+#'   URLs, this parameter can also be a list with same length as \code{url} with
+#'   each element of the list containing a single number or four numbers  to use
+#'   for the corresponding URL.
 #' @param zoom A number specifying the zoom factor. A zoom factor of 2 will
 #'   result in twice as many pixels vertically and horizontally. Note that using
 #'   2 is not exactly the same as taking a screenshot on a HiDPI (Retina)
@@ -44,6 +50,12 @@
 #'
 #' # Might need a longer delay for all assets to display
 #' webshot("http://rstudio.github.io/leaflet", delay = 0.5)
+#'
+#' # One can also take screenshots of several URLs with only one command.
+#' # This is more efficient than calling multiple times 'webshot'.
+#' webshot(c("https://github.com/rstudio/shiny",
+#'           "http://rstudio.github.io/leaflet"),
+#'         delay = 0.5)
 #'
 #' # Clip to the viewport
 #' webshot("http://rstudio.github.io/leaflet", "leaflet-viewport.png",
@@ -115,8 +127,8 @@ webshot <- function(
   if (length(url) > 1) {
     if (length(file) == 1) {
       file <- sapply(1:length(url), function(i) {
-        replacement <- sprintf("%03d.png", i)
-        gsub("\\.png$", replacement, file)
+        replacement <- sprintf("%03d.\\1", i)
+        gsub("\\.(.{3,4})$", replacement, file)
       })
     } else if (length(file) != length(url)) {
       stop("parameters 'url' and 'file' should have same length")
@@ -150,19 +162,28 @@ webshot <- function(
     }
   }
 
-  data <- data.frame(url = url, file = file)
+  data <- data.frame(url = url, file = file, vwidth = vwidth, vheight = vheight)
+
+  # Params selector and expand can be either a vector that need to be concatenated
+  # or a list of such vectors. This function can be used to convert them into a
+  # character vector with the desired format.
+  argToVec <- function(arg) {
+    if (!is.list(arg)) return(paste(arg, collapse = ","))
+    sapply(arg, function(x) {
+      if (is.null(x) || is.na(x)) return(NA_character_)
+      else paste(x, collapse = ",")
+    })
+  }
+
+  if (!is.null(selector)) data$selector <- argToVec(selector)
+  if (!is.null(delay)) data$delay <- delay
+  if (!is.null(expand)) data$expand <- argToVec(expand)
+  if (!is.null(zoom)) data$zoom <- zoom
+  if (!is.null(eval)) data$eval <- eval
 
   args <- dropNulls(list(
     shQuote(system.file("webshot.js", package = "webshot")),
-    shQuote(jsonlite::toJSON(data)),
-    paste0("--vwidth=", vwidth),
-    paste0("--vheight=", vheight),
-    if (!is.null(cliprect)) paste0("--cliprect=", paste(cliprect, collapse=",")),
-    if (!is.null(selector)) paste0("--selector=", paste(shQuote(selector), collapse=",")),
-    if (!is.null(delay)) paste0("--delay=", delay),
-    if (!is.null(expand)) paste0("--expand=", paste(expand, collapse=",")),
-    if (!is.null(zoom)) paste0("--zoom=", zoom),
-    if (!is.null(eval)) paste0("--eval=", shQuote(eval))
+    shQuote(jsonlite::toJSON(data))
   ))
 
   res <- phantom_run(args)

--- a/R/webshot.R
+++ b/R/webshot.R
@@ -1,8 +1,8 @@
 #' Take a screenshot of a URL
 #'
 #' @param url A vector of URLs to visit.
-#' @param file A Vector of names of output files. Should end with \code{.png},
-#' \code{.pdf}, or \code{.jpeg}.
+#' @param file A vector of names of output files. Should end with \code{.png},
+#'   \code{.pdf}, or \code{.jpeg}.
 #' @param vwidth Viewport width. This is the width of the browser "window".
 #' @param vheight Viewport height This is the height of the browser "window".
 #' @param cliprect Clipping rectangle. If \code{cliprect} and \code{selector}
@@ -14,10 +14,10 @@
 #' @param selector One or more CSS selectors specifying a DOM element to set the
 #'   clipping rectangle to. The screenshot will contain these DOM elements. For
 #'   a given selector, if it has more than one match, only the first one will be
-#'   used. This option is not compatible with \code{cliprect}. When
-#'   taking screenshots of multiple URLs, this parameter can also be a list with
-#'   same length as \code{url} with each element of the list containing a vector
-#'   of CSS selectors to use for the corresponding URL.
+#'   used. This option is not compatible with \code{cliprect}. When taking
+#'   screenshots of multiple URLs, this parameter can also be a list with same
+#'   length as \code{url} with each element of the list containing a vector of
+#'   CSS selectors to use for the corresponding URL.
 #' @param delay Time to wait before taking screenshot, in seconds. Sometimes a
 #'   longer delay is needed for all assets to display properly.
 #' @param expand A numeric vector specifying how many pixels to expand the
@@ -124,12 +124,15 @@ webshot <- function(
     stop("Need url.")
   }
 
+  # If user provides multiple URLs but only one file name, then the below code
+  # generates as many file names as URLs following the pattern
+  # "filename001.png", "filename002.png", ... (or whatever extension it is)
   if (length(url) > 1) {
     if (length(file) == 1) {
-      file <- sapply(1:length(url), function(i) {
-        replacement <- sprintf("%03d.\\1", i)
-        gsub("\\.(.{3,4})$", replacement, file)
-      })
+      file <- vapply(1:length(url), FUN.VALUE = "", function(i) {
+          replacement <- sprintf("%03d.\\1", i)
+          gsub("\\.(.{3,4})$", replacement, file)
+        })
     } else if (length(file) != length(url)) {
       stop("parameters 'url' and 'file' should have same length")
     }
@@ -169,15 +172,15 @@ webshot <- function(
   # character vector with the desired format.
   argToVec <- function(arg) {
     if (!is.list(arg)) return(paste(arg, collapse = ","))
-    sapply(arg, function(x) {
-      if (is.null(x) || is.na(x)) return(NA_character_)
+    vapply(arg, FUN.VALUE = "", function(x) {
+      if (is.null(x) || is.na(x)) NA_character_
       else paste(x, collapse = ",")
     })
   }
 
   if (!is.null(selector)) data$selector <- argToVec(selector)
-  if (!is.null(delay)) data$delay <- delay
   if (!is.null(expand)) data$expand <- argToVec(expand)
+  if (!is.null(delay)) data$delay <- delay
   if (!is.null(zoom)) data$zoom <- zoom
   if (!is.null(eval)) data$eval <- eval
 

--- a/R/webshot.R
+++ b/R/webshot.R
@@ -129,12 +129,12 @@ webshot <- function(
   # "filename001.png", "filename002.png", ... (or whatever extension it is)
   if (length(url) > 1) {
     if (length(file) == 1) {
-      file <- vapply(1:length(url), FUN.VALUE = "", function(i) {
+      file <- vapply(1:length(url), FUN.VALUE = character(1), function(i) {
           replacement <- sprintf("%03d.\\1", i)
           gsub("\\.(.{3,4})$", replacement, file)
         })
     } else if (length(file) != length(url)) {
-      stop("parameters 'url' and 'file' should have same length")
+      stop("'url' and 'file' should have same length")
     }
   }
 
@@ -160,8 +160,11 @@ webshot <- function(
   }
 
   if (!is.null(expand)) {
-    if (!(length(expand) %in% c(1, 4))) {
-      stop("expand must either have 1 or 4 values");
+    # check that expand is a vector of length 1 or 4 or a list of such vectors
+    if (!is.list(expand)) expand <- list(expand)
+    lengths <- vapply(expand, length, numeric(1))
+    if (any(!lengths %in% c(1, 4))) {
+      stop("'expand' must be a vector with one or four numbers, or a list of such vectors.")
     }
   }
 
@@ -172,7 +175,7 @@ webshot <- function(
   # character vector with the desired format.
   argToVec <- function(arg) {
     if (!is.list(arg)) return(paste(arg, collapse = ","))
-    vapply(arg, FUN.VALUE = "", function(x) {
+    vapply(arg, FUN.VALUE = character(1), function(x) {
       if (is.null(x) || is.na(x)) NA_character_
       else paste(x, collapse = ",")
     })

--- a/R/webshot.R
+++ b/R/webshot.R
@@ -15,7 +15,7 @@
 #'   of multiple URLs, this parameter can also be a list with same length as
 #'   \code{url} with each element of the list being "viewport" or a
 #'   four-elements numeric vector. This option is not compatible with
-#'   \code{selector}
+#'   \code{selector}.
 #' @param selector One or more CSS selectors specifying a DOM element to set the
 #'   clipping rectangle to. The screenshot will contain these DOM elements. For
 #'   a given selector, if it has more than one match, only the first one will be

--- a/R/webshot.R
+++ b/R/webshot.R
@@ -112,6 +112,17 @@ webshot <- function(
     stop("Need url.")
   }
 
+  if (length(url) > 1) {
+    if (length(file) == 1) {
+      file <- sapply(1:length(url), function(i) {
+        replacement <- sprintf("%03d.png", i)
+        gsub("\\.png$", replacement, file)
+      })
+    } else if (length(file) != length(url)) {
+      stop("parameters 'url' and 'file' should have same length")
+    }
+  }
+
   if (is_windows()) {
     url <- fix_windows_url(url)
   }
@@ -139,10 +150,11 @@ webshot <- function(
     }
   }
 
+  data <- data.frame(url = url, file = file)
+
   args <- dropNulls(list(
     shQuote(system.file("webshot.js", package = "webshot")),
-    url,
-    file,
+    shQuote(jsonlite::toJSON(data)),
     paste0("--vwidth=", vwidth),
     paste0("--vheight=", vheight),
     if (!is.null(cliprect)) paste0("--cliprect=", paste(cliprect, collapse=",")),

--- a/R/webshot.R
+++ b/R/webshot.R
@@ -150,7 +150,7 @@ webshot <- function(
 
   } else if (is.null(selector) && !is.null(cliprect)) {
     if (!is.list(cliprect)) cliprect <- list(cliprect)
-    vapply(cliprect, FUN.VALUE=logical(1), function(x) {
+    cliprect <- lapply(cliprect, function(x) {
       if (is.character(x)) {
         if (x == "viewport") {
           x <- c(0, 0, vwidth, vheight)
@@ -162,6 +162,7 @@ webshot <- function(
           stop("'cliprect' must be a 4-element numeric vector or a list of such vectors")
         }
       }
+      x
     })
   }
 
@@ -189,7 +190,7 @@ webshot <- function(
     })
   }
 
-  if (!is.null(cliprect)) opts$cliprect <- cliprect
+  if (!is.null(cliprect)) opts$cliprect <- argToVec(cliprect)
   if (!is.null(selector)) opts$selector <- argToVec(selector)
   if (!is.null(expand)) opts$expand <- argToVec(expand)
   if (!is.null(delay)) opts$delay <- delay

--- a/R/webshot.R
+++ b/R/webshot.R
@@ -9,8 +9,11 @@
 #'   are both unspecified, the clipping rectangle will contain the entire page.
 #'   This can be the string \code{"viewport"}, in which case the clipping
 #'   rectangle matches the viewport size, or it can be a four-element numeric
-#'   vector specifying the top, left, width, and height. This option is not
-#'   compatible with \code{selector}.
+#'   vector specifying the top, left, width, and height. When taking screenshots
+#'   of multiple URLs, this parameter can also be a list with same length as
+#'   \code{url} with each element of the list being "viewport" or a
+#'   four-elements numeric vector. This option is not compatible with
+#'   \code{selector}
 #' @param selector One or more CSS selectors specifying a DOM element to set the
 #'   clipping rectangle to. The screenshot will contain these DOM elements. For
 #'   a given selector, if it has more than one match, only the first one will be
@@ -146,18 +149,23 @@ webshot <- function(
     stop("Can't specify both cliprect and selector.")
 
   } else if (is.null(selector) && !is.null(cliprect)) {
-    if (is.character(cliprect)) {
-      if (cliprect == "viewport") {
-        cliprect <- c(0, 0, vwidth, vheight)
+    if (!is.list(cliprect)) cliprect <- list(cliprect)
+    vapply(cliprect, FUN.VALUE=logical(1), function(x) {
+      if (is.character(x)) {
+        if (x == "viewport") {
+          x <- c(0, 0, vwidth, vheight)
+        } else {
+          stop("Invalid value for cliprect: ", x)
+        }
       } else {
-        stop("Invalid value for cliprect: ", cliprect)
+        if (!is.numeric(x) || length(x) != 4) {
+          stop("'cliprect' must be a 4-element numeric vector or a list of such vectors")
+        }
       }
-    } else {
-      if (!is.numeric(cliprect) || length(cliprect) != 4) {
-        stop("cliprect must be a 4-element numeric vector")
-      }
-    }
+    })
   }
+
+  if (!is.null(selector) && !is.list(selector)) selector <- list(selector)
 
   if (!is.null(expand)) {
     # check that expand is a vector of length 1 or 4 or a list of such vectors
@@ -168,28 +176,29 @@ webshot <- function(
     }
   }
 
-  data <- data.frame(url = url, file = file, vwidth = vwidth, vheight = vheight)
+  # Create the table that contains all options for each screenshot
+  opts <- data.frame(url = url, file = file, vwidth = vwidth, vheight = vheight)
 
-  # Params selector and expand can be either a vector that need to be concatenated
-  # or a list of such vectors. This function can be used to convert them into a
-  # character vector with the desired format.
+  # Params selector, cliprect and expand can be either a vector that need to be
+  # concatenated or a list of such vectors. This function can be used to convert
+  # them into a character vector with the desired format.
   argToVec <- function(arg) {
-    if (!is.list(arg)) return(paste(arg, collapse = ","))
     vapply(arg, FUN.VALUE = character(1), function(x) {
       if (is.null(x) || is.na(x)) NA_character_
       else paste(x, collapse = ",")
     })
   }
 
-  if (!is.null(selector)) data$selector <- argToVec(selector)
-  if (!is.null(expand)) data$expand <- argToVec(expand)
-  if (!is.null(delay)) data$delay <- delay
-  if (!is.null(zoom)) data$zoom <- zoom
-  if (!is.null(eval)) data$eval <- eval
+  if (!is.null(cliprect)) opts$cliprect <- cliprect
+  if (!is.null(selector)) opts$selector <- argToVec(selector)
+  if (!is.null(expand)) opts$expand <- argToVec(expand)
+  if (!is.null(delay)) opts$delay <- delay
+  if (!is.null(zoom)) opts$zoom <- zoom
+  if (!is.null(eval)) opts$eval <- eval
 
   args <- dropNulls(list(
     shQuote(system.file("webshot.js", package = "webshot")),
-    shQuote(jsonlite::toJSON(data))
+    shQuote(jsonlite::toJSON(opts))
   ))
 
   res <- phantom_run(args)

--- a/R/webshot.R
+++ b/R/webshot.R
@@ -30,7 +30,7 @@
 #'   that many pixels on all sides. If four numbers, they specify the top,
 #'   right, bottom, and left, in that order. When taking screenshots of multiple
 #'   URLs, this parameter can also be a list with same length as \code{url} with
-#'   each element of the list containing a single number or four numbers  to use
+#'   each element of the list containing a single number or four numbers to use
 #'   for the corresponding URL.
 #' @param zoom A number specifying the zoom factor. A zoom factor of 2 will
 #'   result in twice as many pixels vertically and horizontally. Note that using

--- a/README.Rmd
+++ b/README.Rmd
@@ -68,6 +68,28 @@ webshot("https://www.r-project.org/", "r-sidebar-zoom.png",
         selector = ".sidebar", zoom = 2)
 ```
 
+### Vectorization
+
+All parameters of function `webshot`. That means that multiple screenshots can be taken with a single command. When taking a lot of screenshots, vectorization can divide by 5 the execution time.
+
+```{r eval=FALSE}
+# Take a screenshot of different sites
+webshot(c("https://www.r-project.org/", "https://github.com/wch/webshot"),
+        file = c("r.png", "webshot.png"))
+
+# Save screenshots of the same site in different formats
+webshot("https://www.r-project.org/", file = c("r.png", "r.pdf"))
+
+# Take screenshots of different sections of the same site. 
+# Note that unlike arguments "url" and "file", a list is required to specify 
+# multiple selectors. This is also the case for arguments "cliprect" and 
+# "expand"
+webshot("http://rstudio.github.io/leaflet/",
+        file = c("leaflet_features.png", "leaflet_install.png"),
+        selector = list("#features", "#installation"))
+```
+
+
 
 ### Screenshots of Shiny applications
 
@@ -101,7 +123,7 @@ webshot("https://www.r-project.org/", "r-small.png") %>%
 ```
 
 
-```{r echo=FALSE}
+```{r eval=FALSE, echo=FALSE}
 # Take the screenshots that are shown below
 
 webshot("https://www.r-project.org/", cliprect = c(0, 0, 992, 500),

--- a/README.md
+++ b/README.md
@@ -62,6 +62,27 @@ webshot("https://www.r-project.org/", "r-sidebar-zoom.png",
         selector = ".sidebar", zoom = 2)
 ```
 
+### Vectorization
+
+All parameters of function `webshot`. That means that multiple screenshots can be taken with a single command. When taking a lot of screenshots, vectorization can divide by 5 the execution time.
+
+``` r
+# Take a screenshot of different sites
+webshot(c("https://www.r-project.org/", "https://github.com/wch/webshot"),
+        file = c("r.png", "webshot.png"))
+
+# Save screenshots of the same site in different formats
+webshot("https://www.r-project.org/", file = c("r.png", "r.pdf"))
+
+# Take screenshots of different sections of the same site. 
+# Note that unlike arguments "url" and "file", a list is required to specify 
+# multiple selectors. This is also the case for arguments "cliprect" and 
+# "expand"
+webshot("http://rstudio.github.io/leaflet/",
+        file = c("leaflet_features.png", "leaflet_install.png"),
+        selector = list("#features", "#installation"))
+```
+
 ### Screenshots of Shiny applications
 
 The `appshot()` function will run a Shiny app locally in a separate R process, and take a screenshot of it. After taking the screenshot, it will kill the R process that is running the Shiny app.

--- a/inst/utils.js
+++ b/inst/utils.js
@@ -19,7 +19,7 @@ exports.parseArgs = function(args) {
 };
 
 // Copy properties from object b that are not defined in object a into object a.
-exports.merge = function(a, b) {
+exports.fillMissing = function(a, b) {
   for (var i in b) {
     if (b.hasOwnProperty(i) && !a.hasOwnProperty(i))
       a[i] = b[i];

--- a/inst/utils.js
+++ b/inst/utils.js
@@ -18,10 +18,10 @@ exports.parseArgs = function(args) {
   return opts;
 };
 
-// Merge properties from object b into object a
+// Copy properties from object b that are not defined in object a into object a.
 exports.merge = function(a, b) {
   for (var i in b) {
-    if (b.hasOwnProperty(i))
+    if (b.hasOwnProperty(i) && !a.hasOwnProperty(i))
       a[i] = b[i];
   }
   return a;

--- a/inst/webshot.js
+++ b/inst/webshot.js
@@ -25,54 +25,52 @@ var args = system.args;
 
 if (args.length < 2) {
   console.log('Usage:\n' +
-    '  phantomjs webshot.js <data> [options]');
+    '  phantomjs webshot.js <data>');
   phantom.exit(1);
 }
 
 var data = JSON.parse(args[1]);
 
-var opts = utils.parseArgs(args.slice(2));
-opts = utils.merge(opt_defaults, opts);
-
-// These should be numbers
-if (opts.vwidth)  opts.vwidth  = +opts.vwidth;
-if (opts.vheight) opts.vheight = +opts.vheight;
-if (opts.delay)   opts.delay   = +opts.delay;
-if (opts.zoom)    opts.zoom    = +opts.zoom;
-
-// This should be four numbers separated by ","
-if (opts.cliprect) {
-  opts.cliprect = opts.cliprect.split(",");
-  opts.cliprect = opts.cliprect.map(function(x) { return +x; });
-}
-
-// Can be 1 or 4 numbers separated by ","
-if (opts.expand) {
-  opts.expand = opts.expand.split(",");
-  opts.expand = opts.expand.map(function(x) { return +x; });
-  if (opts.expand.length !== 1 && opts.expand.length !== 4) {
-    console.log("'expand' must have either 1 or 4 values.");
-    phantom.exit(1);
-  }
-}
-
-// Can have multiple selectors
-if (opts.selector) {
-  opts.selector = opts.selector.split(",");
-}
-
 // =====================================================================
 // Screenshot
 // =====================================================================
 
-casper.start().zoom(opts.zoom)
-  .viewport(opts.zoom * opts.vwidth, opts.zoom * opts.vheight);
+casper.start();
 
 casper.eachThen(data, function(response) {
   var url = response.data.url;
   var file = response.data.file;
+  var opts = response.data;
+
+  // Prepare options
+  opts = utils.merge(opt_defaults, opts);
+
+  // This should be four numbers separated by ","
+  if (opts.cliprect) {
+    opts.cliprect = opts.cliprect.split(",");
+    opts.cliprect = opts.cliprect.map(function(x) { return +x; });
+  }
+
+  // Can be 1 or 4 numbers separated by ","
+  if (opts.expand) {
+    opts.expand = opts.expand.split(",");
+    opts.expand = opts.expand.map(function(x) { return +x; });
+    if (opts.expand.length !== 1 && opts.expand.length !== 4) {
+      console.log("'expand' must have either 1 or 4 values.");
+      phantom.exit(1);
+    }
+  }
+
+  // Can have multiple selectors
+  if (opts.selector) {
+    opts.selector = opts.selector.split(",");
+  }
+
+  // Go to url and perform the desired screenshot
   this.thenOpen(url, function(r) {
-    this.wait(opts.delay * 1000);
+    this.zoom(opts.zoom)
+      .viewport(opts.zoom * opts.vwidth, opts.zoom * opts.vheight)
+      .wait(opts.delay * 1000);
     var cr = findClipRect(opts, this);
     this.capture(file, cr);
   });

--- a/inst/webshot.js
+++ b/inst/webshot.js
@@ -69,13 +69,13 @@ casper.eachThen(optsList, function(response) {
   }
 
   // Go to url and perform the desired screenshot
-  this.thenOpen(opts.url, function(r) {
-    this.zoom(opts.zoom)
-      .viewport(opts.zoom * opts.vwidth, opts.zoom * opts.vheight)
-      .wait(opts.delay * 1000);
-    var cr = findClipRect(opts, this);
-    this.capture(opts.file, cr);
-  });
+  casper.zoom(opts.zoom)
+    .viewport(opts.zoom * opts.vwidth, opts.zoom * opts.vheight)
+    .thenOpen(opts.url, function(r) {
+      casper.wait(opts.delay * 1000);
+      var cr = findClipRect(opts, this);
+      casper.capture(opts.file, cr);
+    });
 });
 
 casper.run();

--- a/inst/webshot.js
+++ b/inst/webshot.js
@@ -45,7 +45,7 @@ casper.eachThen(optsList, function(response) {
   var opts = response.data;
 
   // Prepare options
-  opts = utils.merge(opt_defaults, opts);
+  opts = utils.merge(opts, opt_defaults);
 
   // This should be four numbers separated by ","
   if (opts.cliprect) {

--- a/inst/webshot.js
+++ b/inst/webshot.js
@@ -23,15 +23,15 @@ var opt_defaults = {
 // =====================================================================
 var args = system.args;
 
-if (args.length < 3) {
+if (args.length < 2) {
   console.log('Usage:\n' +
-    '  phantomjs webshot.js <url> <name>.png [options]');
+    '  phantomjs webshot.js <data> [options]');
   phantom.exit(1);
 }
 
-var url = args[1];
-var filename = args[2];
-var opts = utils.parseArgs(args.slice(3));
+var data = JSON.parse(args[1]);
+
+var opts = utils.parseArgs(args.slice(2));
 opts = utils.merge(opt_defaults, opts);
 
 // These should be numbers
@@ -64,19 +64,18 @@ if (opts.selector) {
 // =====================================================================
 // Screenshot
 // =====================================================================
-casper.start(url).zoom(opts.zoom)
+
+casper.start().zoom(opts.zoom)
   .viewport(opts.zoom * opts.vwidth, opts.zoom * opts.vheight);
 
-if (opts.delay > 0)
-  casper.wait(opts.delay * 1000);
-
-if (opts.eval) {
-  eval(opts.eval);
-}
-
-casper.then(function() {
-  var cr = findClipRect(opts, this);
-  this.capture(filename, cr);
+casper.eachThen(data, function(response) {
+  var url = response.data.url;
+  var file = response.data.file;
+  this.thenOpen(url, function(r) {
+    this.wait(opts.delay * 1000);
+    var cr = findClipRect(opts, this);
+    this.capture(file, cr);
+  });
 });
 
 casper.run();

--- a/inst/webshot.js
+++ b/inst/webshot.js
@@ -29,7 +29,8 @@ var args = system.args;
 
 if (args.length < 2) {
   console.log(
-    'usage: phantomjs webshot.js <optsList>\n' +
+    'Usage:\n' +
+    '  phantomjs webshot.js <optsList>\n' +
     '\n' +
     'optsList is a JSON array containing configuration for each screenshot.\n' +
     'For instance:\n' +
@@ -45,7 +46,7 @@ var optsList = JSON.parse(args[1]);
 
 casper.start();
 casper.options.onLoadError = function(c, url) {
-  console.log("Can not load ", url);
+  console.log("Could not load ", url);
   phantom.exit(1);
 };
 
@@ -53,7 +54,7 @@ casper.eachThen(optsList, function(response) {
   var opts = response.data;
 
   // Prepare options
-  opts = utils.merge(opts, opt_defaults);
+  opts = utils.fillMissing(opts, opt_defaults);
 
   // This should be four numbers separated by ","
   if (opts.cliprect) {
@@ -77,12 +78,12 @@ casper.eachThen(optsList, function(response) {
   }
 
   // Go to url and perform the desired screenshot
-  casper.zoom(opts.zoom)
+  this.zoom(opts.zoom)
     .viewport(opts.zoom * opts.vwidth, opts.zoom * opts.vheight)
-    .thenOpen(opts.url, function(r) {
-      casper.wait(opts.delay * 1000, function() {
-        var cr = findClipRect(opts, casper);
-        casper.capture(opts.file, cr);
+    .thenOpen(opts.url, function() {
+      this.wait(opts.delay * 1000, function() {
+        var cr = findClipRect(opts, this);
+        this.capture(opts.file, cr);
       });
     });
 });

--- a/inst/webshot.js
+++ b/inst/webshot.js
@@ -28,8 +28,12 @@ var opt_defaults = {
 var args = system.args;
 
 if (args.length < 2) {
-  console.log('Usage:\n' +
-    '  phantomjs webshot.js <data>');
+  console.log(
+    'usage: phantomjs webshot.js <optsList>\n' +
+    '\n' +
+    'optsList is a JSON array containing configuration for each screenshot.\n' +
+    'For instance:\n' +
+    '\'[{"url":"url1.html","file":"file1.png"},{"url":"url2.html","file":"fil2.png","zoom":2}]\'');
   phantom.exit(1);
 }
 

--- a/inst/webshot.js
+++ b/inst/webshot.js
@@ -1,7 +1,11 @@
-
 // This must be executed with phantomjs
 // Take a screenshot of a URL and saves it to a .png file
-// phantomjs webshot.js <url> <filename> [options]
+// phantomjs webshot.js <optsList>
+//
+// 'optsList' is a JSON array containing configurations for each screenshot that has
+// to be taken. Each configuration object needs to contain at least properties
+// "url" and "file". For instance:
+// [{"url":"http://rstudio.github.io/leaflet/","file":"webshot.png"}]
 
 var utils = require('./utils');
 var system = require('system');
@@ -29,7 +33,7 @@ if (args.length < 2) {
   phantom.exit(1);
 }
 
-var data = JSON.parse(args[1]);
+var optsList = JSON.parse(args[1]);
 
 // =====================================================================
 // Screenshot
@@ -37,9 +41,7 @@ var data = JSON.parse(args[1]);
 
 casper.start();
 
-casper.eachThen(data, function(response) {
-  var url = response.data.url;
-  var file = response.data.file;
+casper.eachThen(optsList, function(response) {
   var opts = response.data;
 
   // Prepare options
@@ -67,12 +69,12 @@ casper.eachThen(data, function(response) {
   }
 
   // Go to url and perform the desired screenshot
-  this.thenOpen(url, function(r) {
+  this.thenOpen(opts.url, function(r) {
     this.zoom(opts.zoom)
       .viewport(opts.zoom * opts.vwidth, opts.zoom * opts.vheight)
       .wait(opts.delay * 1000);
     var cr = findClipRect(opts, this);
-    this.capture(file, cr);
+    this.capture(opts.file, cr);
   });
 });
 

--- a/inst/webshot.js
+++ b/inst/webshot.js
@@ -72,9 +72,10 @@ casper.eachThen(optsList, function(response) {
   casper.zoom(opts.zoom)
     .viewport(opts.zoom * opts.vwidth, opts.zoom * opts.vheight)
     .thenOpen(opts.url, function(r) {
-      casper.wait(opts.delay * 1000);
-      var cr = findClipRect(opts, this);
-      casper.capture(opts.file, cr);
+      casper.wait(opts.delay * 1000, function() {
+        var cr = findClipRect(opts, casper);
+        casper.capture(opts.file, cr);
+      });
     });
 });
 

--- a/inst/webshot.js
+++ b/inst/webshot.js
@@ -40,6 +40,10 @@ var optsList = JSON.parse(args[1]);
 // =====================================================================
 
 casper.start();
+casper.options.onLoadError = function(c, url) {
+  console.log("Can not load ", url);
+  phantom.exit(1);
+};
 
 casper.eachThen(optsList, function(response) {
   var opts = response.data;

--- a/man/appshot.Rd
+++ b/man/appshot.Rd
@@ -10,8 +10,10 @@ appshot(app, file = "webshot.png", ..., port = getOption("shiny.port"),
 \arguments{
 \item{app}{A Shiny app object, or a string naming an app directory.}
 
-\item{file}{Name of output file. Should end with \code{.png}, \code{.pdf}, or
-\code{.jpeg}.}
+\item{file}{A vector of names of output files. Should end with \code{.png},
+\code{.pdf}, or \code{.jpeg}. If several screenshots have to be taken and
+only one filename is provided, then the function appends the index number
+of the screenshot to the file name.}
 
 \item{...}{Other arguments to pass on to \code{\link{webshot}}.}
 

--- a/man/resize.Rd
+++ b/man/resize.Rd
@@ -7,11 +7,13 @@
 resize(filename, geometry)
 }
 \arguments{
-\item{filename}{Name of image to resize.}
+\item{filename}{Character vector containing the path of images to resize.}
 
 \item{geometry}{Scaling specification. Can be a percent, as in \code{"50\%"},
 or pixel dimensions like \code{"120x120"}, \code{"120x"}, or \code{"x120"}.
-Any valid ImageMagick geometry specifation can be used.}
+Any valid ImageMagick geometry specifation can be used. If \code{filename}
+contains multiple images, this can be a vector to specify distinct sizes
+for each image.}
 }
 \description{
 This does not change size of the image in pixels, nor does it affect

--- a/man/shrink.Rd
+++ b/man/shrink.Rd
@@ -7,7 +7,8 @@
 shrink(filename)
 }
 \arguments{
-\item{filename}{Name of image to shrink. Must be a PNG file.}
+\item{filename}{Character vector containing the path of images to resize.
+Must be PNG files.}
 }
 \description{
 This does not change size of the image in pixels, nor does it affect

--- a/man/webshot.Rd
+++ b/man/webshot.Rd
@@ -28,7 +28,7 @@ vector specifying the top, left, width, and height. When taking screenshots
 of multiple URLs, this parameter can also be a list with same length as
 \code{url} with each element of the list being "viewport" or a
 four-elements numeric vector. This option is not compatible with
-\code{selector}}
+\code{selector}.}
 
 \item{selector}{One or more CSS selectors specifying a DOM element to set the
 clipping rectangle to. The screenshot will contain these DOM elements. For

--- a/man/webshot.Rd
+++ b/man/webshot.Rd
@@ -43,7 +43,7 @@ clipping rectangle by. If one number, the rectangle will be expanded by
 that many pixels on all sides. If four numbers, they specify the top,
 right, bottom, and left, in that order. When taking screenshots of multiple
 URLs, this parameter can also be a list with same length as \code{url} with
-each element of the list containing a single number or four numbers  to use
+each element of the list containing a single number or four numbers to use
 for the corresponding URL.}
 
 \item{delay}{Time to wait before taking screenshot, in seconds. Sometimes a
@@ -78,7 +78,7 @@ webshot("https://github.com/rstudio/shiny")
 webshot("http://rstudio.github.io/leaflet", delay = 0.5)
 
 # One can also take screenshots of several URLs with only one command.
-# This is more efficient than calling multiple times 'webshot'.
+# This is more efficient than calling 'webshot' multiple times.
 webshot(c("https://github.com/rstudio/shiny",
           "http://rstudio.github.io/leaflet"),
         delay = 0.5)

--- a/man/webshot.Rd
+++ b/man/webshot.Rd
@@ -11,8 +11,10 @@ webshot(url = NULL, file = "webshot.png", vwidth = 992, vheight = 744,
 \arguments{
 \item{url}{A vector of URLs to visit.}
 
-\item{file}{A Vector of names of output files. Should end with \code{.png},
-\code{.pdf}, or \code{.jpeg}.}
+\item{file}{A vector of names of output files. Should end with \code{.png},
+\code{.pdf}, or \code{.jpeg}. If several screenshots have to be taken and
+only one filename is provided, then the function appends the index number
+of the screenshot to the file name.}
 
 \item{vwidth}{Viewport width. This is the width of the browser "window".}
 
@@ -22,16 +24,19 @@ webshot(url = NULL, file = "webshot.png", vwidth = 992, vheight = 744,
 are both unspecified, the clipping rectangle will contain the entire page.
 This can be the string \code{"viewport"}, in which case the clipping
 rectangle matches the viewport size, or it can be a four-element numeric
-vector specifying the top, left, width, and height. This option is not
-compatible with \code{selector}.}
+vector specifying the top, left, width, and height. When taking screenshots
+of multiple URLs, this parameter can also be a list with same length as
+\code{url} with each element of the list being "viewport" or a
+four-elements numeric vector. This option is not compatible with
+\code{selector}}
 
 \item{selector}{One or more CSS selectors specifying a DOM element to set the
 clipping rectangle to. The screenshot will contain these DOM elements. For
 a given selector, if it has more than one match, only the first one will be
-used. This option is not compatible with \code{cliprect}. When
-taking screenshots of multiple URLs, this parameter can also be a list with
-same length as \code{url} with each element of the list containing a vector
-of CSS selectors to use for the corresponding URL.}
+used. This option is not compatible with \code{cliprect}. When taking
+screenshots of multiple URLs, this parameter can also be a list with same
+length as \code{url} with each element of the list containing a vector of
+CSS selectors to use for the corresponding URL.}
 
 \item{expand}{A numeric vector specifying how many pixels to expand the
 clipping rectangle by. If one number, the rectangle will be expanded by

--- a/man/webshot.Rd
+++ b/man/webshot.Rd
@@ -9,10 +9,10 @@ webshot(url = NULL, file = "webshot.png", vwidth = 992, vheight = 744,
   zoom = 1, eval = NULL)
 }
 \arguments{
-\item{url}{A URL to visit.}
+\item{url}{A vector of URLs to visit.}
 
-\item{file}{Name of output file. Should end with \code{.png}, \code{.pdf}, or
-\code{.jpeg}.}
+\item{file}{A Vector of names of output files. Should end with \code{.png},
+\code{.pdf}, or \code{.jpeg}.}
 
 \item{vwidth}{Viewport width. This is the width of the browser "window".}
 
@@ -28,12 +28,18 @@ compatible with \code{selector}.}
 \item{selector}{One or more CSS selectors specifying a DOM element to set the
 clipping rectangle to. The screenshot will contain these DOM elements. For
 a given selector, if it has more than one match, only the first one will be
-used. This option is not compatible with \code{cliprect}.}
+used. This option is not compatible with \code{cliprect}. When
+taking screenshots of multiple URLs, this parameter can also be a list with
+same length as \code{url} with each element of the list containing a vector
+of CSS selectors to use for the corresponding URL.}
 
 \item{expand}{A numeric vector specifying how many pixels to expand the
 clipping rectangle by. If one number, the rectangle will be expanded by
 that many pixels on all sides. If four numbers, they specify the top,
-right, bottom, and left, in that order.}
+right, bottom, and left, in that order. When taking screenshots of multiple
+URLs, this parameter can also be a list with same length as \code{url} with
+each element of the list containing a single number or four numbers  to use
+for the corresponding URL.}
 
 \item{delay}{Time to wait before taking screenshot, in seconds. Sometimes a
 longer delay is needed for all assets to display properly.}
@@ -65,6 +71,12 @@ webshot("https://github.com/rstudio/shiny")
 
 # Might need a longer delay for all assets to display
 webshot("http://rstudio.github.io/leaflet", delay = 0.5)
+
+# One can also take screenshots of several URLs with only one command.
+# This is more efficient than calling multiple times 'webshot'.
+webshot(c("https://github.com/rstudio/shiny",
+          "http://rstudio.github.io/leaflet"),
+        delay = 0.5)
 
 # Clip to the viewport
 webshot("http://rstudio.github.io/leaflet", "leaflet-viewport.png",


### PR DESCRIPTION
Hello,

This pull request solves #32 . It vectorizes all arguments of "webshot" in order to improve performance when taking a lot of screenshots. For instance, on my laptop, taking 10 screenshots with default parameters  takes 7 seconds instead of  27 seconds.

Parameters for each screenshot are passed to script webshot.js as a JSON array. Then `casper.eachThen` is used to loop over each configuration object. 

