### PR TITLE
 Add R version 3.3.2 to checks for download_no_libcurl.

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -165,7 +165,8 @@ available_port <- function(port) {
 # 403 for HEAD requests. See
 # https://stat.ethz.ch/pipermail/r-devel/2016-June/072852.html
 download <- function(url, destfile, mode = "w") {
-  if (getRversion() == "3.3.0" || getRversion() == "3.3.1") {
+  if (getRversion() == "3.3.0" || getRversion() == "3.3.1" ||
+      getRversion() == "3.3.2") {
     download_no_libcurl(url, destfile, mode = mode)
 
   } else if (is_windows() && getRversion() < "3.2") {

--- a/R/utils.R
+++ b/R/utils.R
@@ -165,8 +165,7 @@ available_port <- function(port) {
 # 403 for HEAD requests. See
 # https://stat.ethz.ch/pipermail/r-devel/2016-June/072852.html
 download <- function(url, destfile, mode = "w") {
-  if (getRversion() == "3.3.0" || getRversion() == "3.3.1" ||
-      getRversion() == "3.3.2") {
+  if (getRversion() >= "3.3.0") {
     download_no_libcurl(url, destfile, mode = mode)
 
   } else if (is_windows() && getRversion() < "3.2") {


### PR DESCRIPTION
For me (on OSX, R 3.3.2), this fixes the install / download problem referenced in #22.

Thank you for `webshot`!