### PR TITLE
Add basic `appshot.shiny.appobj` functionality

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,6 +5,7 @@ Authors@R: c(
     person("Winston", "Chang", email = "winston@rstudio.com", role = c("aut", "cre")),
     person("Yihui", "Xie", role = "ctb"),
     person("Francois", "Guillem", role = "ctb"),
+    person("Barret", "Schloerke", role = "ctb"),
     person("Nicolas", "Perriault", role = "ctb", comment = "The CasperJS library")
     )
 Description: Takes screenshots of web pages, including Shiny applications and R

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,8 @@ Imports:
     magrittr,
     jsonlite,
     withr,
-    processx
+    processx,
+    callr
 Suggests:
     httpuv,
     knitr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,8 +15,6 @@ Depends:
 Imports:
     magrittr,
     jsonlite,
-    withr,
-    processx,
     callr
 Suggests:
     httpuv,
@@ -29,5 +27,5 @@ SystemRequirements: PhantomJS (http://phantomjs.org) for taking screenshots,
     ImageMagick (http://www.imagemagick.org) or GraphicsMagick
     (http://www.graphicsmagick.org) and OptiPNG (http://optipng.sourceforge.net)
     for manipulating images.
-RoxygenNote: 6.0.1.9000
+RoxygenNote: 6.0.1
 URL: https://github.com/wch/webshot/

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@ webshot 0.5.0.9000
 
 * Fixed [#51](https://github.com/wch/webshot/issues/51): Webshot had trouble with some sites that use HTTPS.
 
+* Added `appshot.shiny.appobj` functionality (schloerke, [#55](https://github.com/wch/webshot/pull/55))
+
 webshot 0.5.0
 =============
 

--- a/R/appshot.R
+++ b/R/appshot.R
@@ -1,6 +1,15 @@
 #' Take a screenshot of a Shiny app
 #'
-#' The \code{appshot} performs a \code{\link{webshot}} using two different methods depending upon the object provided.  If a 'character' is provided (pointing to an app.R file or app directory) an isolated background R process is launched to run the Shiny application.  The current R process then captures the \code{\link{webshot}}.  When a Shiny application object is supplied to \code{appshot}, the Shiny application is run in the current R process and an isolated background R process is launched to capture a \code{\link{webshot}}.  Keeping the Shiny appliation in a different process is ideal, shiny application objects are launched in the current R process to avoid scoping errors.
+#' \code{appshot} performs a \code{\link{webshot}} using two different
+#' methods depending upon the object provided.  If a 'character' is provided
+#' (pointing to an app.R file or app directory) an isolated background R
+#' process is launched to run the Shiny application.  The current R process
+#' then captures the \code{\link{webshot}}.  When a Shiny application object
+#' is supplied to \code{appshot}, the Shiny application is run in the current
+#' R process and an isolated background R process is launched to capture a
+#' \code{\link{webshot}}.  Keeping the Shiny application in a different process
+#' is ideal, shiny application objects are launched in the current R process to
+#' avoid scoping errors.
 #'
 #' @inheritParams webshot
 #' @param app A Shiny app object, or a string naming an app directory.

--- a/R/appshot.R
+++ b/R/appshot.R
@@ -1,5 +1,7 @@
 #' Take a screenshot of a Shiny app
 #'
+#' The \code{appshot} performs a \code{\link{webshot}} using two different methods depending upon the object provided.  If a 'character' is provided (pointing to an app.R file or app directory) an isolated background R process is launched to run the Shiny application.  The current R process then captures the \code{\link{webshot}}.  When a Shiny application object is supplied to \code{appshot}, the Shiny application is run in the current R process and an isolated background R process is launched to capture a \code{\link{webshot}}.  Keeping the Shiny appliation in a different process is ideal, shiny application objects are launched in the current R process to avoid scoping errors.
+#'
 #' @inheritParams webshot
 #' @param app A Shiny app object, or a string naming an app directory.
 #' @param port Port that Shiny will listen on.
@@ -7,6 +9,7 @@
 #'   variables and values to set for the Shiny app's R process. These will be
 #'   unset after the process exits. This can be used to pass configuration
 #'   information to a Shiny app.
+#' @param webshot_timeout The maximum number of seconds the phantom application is allowed to run before killing the process. (Only used for Shiny application objects)
 #'
 #' @param ... Other arguments to pass on to \code{\link{webshot}}.
 #'
@@ -25,22 +28,34 @@
 #'
 #' @export
 appshot <- function(app, file = "webshot.png", ...,
-                    port = getOption("shiny.port"), envvars = NULL) {
+                    port = getOption("shiny.port"), envvars = callr::rcmd_safe_env()) {
   UseMethod("appshot")
 }
 
 
 #' @rdname appshot
 #' @export
-appshot.character <- function(app, file = "webshot.png", ...,
-                              port = getOption("shiny.port"), envvars = NULL) {
+appshot.character <- function(
+  app,
+  file = "webshot.png", ...,
+  port = getOption("shiny.port"),
+  envvars = callr::rcmd_safe_env()
+) {
+
   port <- available_port(port)
-  cmd <- sprintf("shiny::runApp('%s', port=%d, display.mode='normal')", app, port)
 
   # Run app in background with envvars
-  withr::with_envvar(envvars, {
-    p <- processx::process$new("R", args = c("--slave", "-e", cmd))
-  })
+  p <- callr::r_bg(
+    function(...) {
+      shiny::runApp(...)
+    },
+    args = list(
+      appDir = app,
+      port = port,
+      display.mode = "normal"
+    ),
+    env = envvars
+  )
 
   # Make sure app is killed on exit
   on.exit({
@@ -59,8 +74,13 @@ appshot.character <- function(app, file = "webshot.png", ...,
 
 #' @rdname appshot
 #' @export
-appshot.shiny.appobj <- function(app, file = "webshot.png", ...,
-                              port = getOption("shiny.port"), envvars = NULL) {
+appshot.shiny.appobj <- function(
+  app,
+  file = "webshot.png", ...,
+  port = getOption("shiny.port"),
+  envvars = callr::rcmd_safe_env(),
+  webshot_timeout = 60
+) {
 
 
   port <- available_port(port)
@@ -79,23 +99,21 @@ appshot.shiny.appobj <- function(app, file = "webshot.png", ...,
     args
   )
 
-  webshot_timeout <- 30
   if(!is.null(args$delay)) {
-    webshot_timeout <- webshot_timeout + 10
+    # webshot_timeout <- webshot_timeout + args$delay
   }
-  webshot_timeout_ms <- webshot_timeout * 1000
-  count <- 0
+  start_time <- as.numeric(Sys.time())
 
   # Add a shiny app observer which checks every 200ms to see if the background r session is alive
   shiny::observe({
     # check the r session rather than the file to avoid race cases or random issues
     if (r_session$is_alive()) {
-      if (count < webshot_timeout_ms) {
+      if ((as.numeric(Sys.time()) - start_time) <= webshot_timeout) {
         # try again later
         shiny::invalidateLater(200)
-        count <<- count + 200
       } else {
         # timeout has occured. close the app and R session
+        message("webshot timed out")
         r_session$kill()
         shiny::stopApp()
       }
@@ -110,5 +128,5 @@ appshot.shiny.appobj <- function(app, file = "webshot.png", ...,
   shiny::runApp(app, port = port, display.mode = "normal")
 
   # return webshot::webshot file value
-  r_session$get_result() # safe to call as the r_session must have ended
+  invisible(r_session$get_result()) # safe to call as the r_session must have ended
 }

--- a/R/appshot.R
+++ b/R/appshot.R
@@ -110,8 +110,9 @@ appshot.shiny.appobj <- function(
     args
   )
 
+  # add a delay to the webshot_timeout if it exists
   if(!is.null(args$delay)) {
-    # webshot_timeout <- webshot_timeout + args$delay
+    webshot_timeout <- webshot_timeout + args$delay
   }
   start_time <- as.numeric(Sys.time())
 

--- a/R/appshot.R
+++ b/R/appshot.R
@@ -14,6 +14,7 @@
 #'
 #' @param ... Other arguments to pass on to \code{\link{webshot}}.
 #'
+#' @rdname appshot
 #' @examples
 #' if (interactive()) {
 #'   appdir <- system.file("examples", "01_hello", package="shiny")
@@ -32,6 +33,7 @@ appshot <- function(app, file = "webshot.png", ...,
   UseMethod("appshot")
 }
 
+#' @rdname appshot
 #' @export
 appshot.shiny.appobj <- function(
   app,
@@ -83,6 +85,7 @@ appshot.shiny.appobj <- function(
   appshot_webshot(file, port, cmd, envvars, ...)
 }
 
+#' @rdname appshot
 #' @export
 appshot.character <- function(app, file = "webshot.png", ...,
                               port = getOption("shiny.port"), envvars = NULL) {

--- a/R/appshot.R
+++ b/R/appshot.R
@@ -7,13 +7,23 @@
 #'   variables and values to set for the Shiny app's R process. These will be
 #'   unset after the process exits. This can be used to pass configuration
 #'   information to a Shiny app.
+#' @param env Environment to export all R objects for the Shiny app object.
+#' @param packages Character vector of R packages required for the Shiny app execution.  Defaults to use the currently attached packages.
+#' @param save_file File used to temporarily save the Shiny app object.
+#' @param env_file File used to temporarily save the Shiny app object server context to execute the app.
 #'
 #' @param ... Other arguments to pass on to \code{\link{webshot}}.
 #'
 #' @examples
 #' if (interactive()) {
 #'   appdir <- system.file("examples", "01_hello", package="shiny")
+#'
+#'   # With a Shiny directory
 #'   appshot(appdir, "01_hello.png")
+#'
+#'   # With a Shiny App object
+#'   shinyapp <- shiny::shinyAppDir(appdir)
+#'   appshot(shinyapp, "01_hello_app.png")
 #' }
 #'
 #' @export
@@ -23,10 +33,54 @@ appshot <- function(app, file = "webshot.png", ...,
 }
 
 #' @export
-appshot.shiny.appobj <- function(app, file = "webshot.png", ...,
-                                 port = getOption("shiny.port"), envvars = NULL) {
-  stop("appshot of Shiny app objects is not yet supported.")
-  # This would require running the app object in this R process
+appshot.shiny.appobj <- function(
+  app,
+  file = "webshot.png", ...,
+  port = getOption("shiny.port"),
+  envvars = NULL,
+  env = NULL,
+  packages = NULL,
+  save_file = tempfile(fileext = ".RData"),
+  env_file = tempfile(fileext = ".RData")
+) {
+  # if the app has a specified port, use it
+  if (is.null(port)) {
+    port <- app$options$port
+  }
+  port <- available_port(port)
+
+  if (is.null(env)) {
+    env <- environment(app$serverFuncSource())
+  }
+  if (is.null(packages)) {
+    packages <- {
+      pkgs <- loadedNamespaces()
+      attached <- paste0("package:", pkgs) %in% search()
+      pkgs[attached]
+    }
+  }
+
+  ## save the app to a file to be reloaded
+  # save to (hopefully) non matching names
+  .appshot.app <- app
+  # get the currently loaded packages
+  .appshot.packages <- packages
+  # save all the items in the server env
+  save(list = ls(envir = env), envir = env, file = env_file, eval.promises = FALSE)
+  # save the app and loaded package names
+  save(.appshot.app, .appshot.packages, file = save_file, eval.promises = FALSE)
+
+  # load env
+  # load .appshot.*
+  # library package
+  # run app
+  cmd <- sprintf(
+    "load('%s'); load('%s'); lapply(.appshot.packages, base::library, character.only = TRUE); shiny::runApp(.appshot.app, port=%d, display.mode='normal')",
+    env_file, save_file, port
+  )
+
+  # take the screen shot
+  appshot_webshot(file, port, cmd, envvars, ...)
 }
 
 #' @export
@@ -35,11 +89,17 @@ appshot.character <- function(app, file = "webshot.png", ...,
   port <- available_port(port)
   cmd <- sprintf("shiny::runApp('%s', port=%d, display.mode='normal')", app, port)
 
+  appshot_webshot(file, port, cmd, envvars, ...)
+}
+
+
+appshot_webshot <- function(file, port, cmd, envvars, ...) {
   # Run app in background with envvars
   withr::with_envvar(envvars, {
     p <- processx::process$new("R", args = c("--slave", "-e", cmd))
   })
 
+  # Make sure app is killed on exit
   on.exit({
     p$kill()
   })
@@ -47,6 +107,7 @@ appshot.character <- function(app, file = "webshot.png", ...,
   # Wait for app to start
   Sys.sleep(0.5)
 
+  # Get screenshot
   fileout <- webshot(sprintf("http://127.0.0.1:%d/", port), file = file, ...)
 
   invisible(fileout)

--- a/R/appshot.R
+++ b/R/appshot.R
@@ -18,7 +18,9 @@
 #'   variables and values to set for the Shiny app's R process. These will be
 #'   unset after the process exits. This can be used to pass configuration
 #'   information to a Shiny app.
-#' @param webshot_timeout The maximum number of seconds the phantom application is allowed to run before killing the process. (Only used for Shiny application objects)
+#' @param webshot_timeout The maximum number of seconds the phantom application
+#' is allowed to run before killing the process. If a delay argument is supplied (in
+#' \code{...}), the delay value is added to the timeout value.
 #'
 #' @param ... Other arguments to pass on to \code{\link{webshot}}.
 #'

--- a/R/process.R
+++ b/R/process.R
@@ -1,0 +1,8 @@
+
+
+r_background_process <- function(..., envvars = NULL) {
+  if (is.null(envvars)) {
+    envvars <- callr::rcmd_safe_env()
+  }
+  callr::r_bg(..., env = envvars)
+}

--- a/R/rmdshot.R
+++ b/R/rmdshot.R
@@ -35,9 +35,7 @@ rmdshot <- function(doc, file = "webshot.png", ..., delay = NULL, rmd_args = lis
     if (is.null(delay)) delay <- 0.2
 
     outfile <- tempfile("webshot", fileext = ".html")
-    render <- rmarkdown::render
-    do.call("render", c(list(doc, output_file = outfile), rmd_args),
-            envir = parent.frame())
+    do.call(rmarkdown::render, c(list(doc, output_file = outfile), rmd_args))
     webshot(outfile, file = file, ...)
   }
 }

--- a/R/rmdshot.R
+++ b/R/rmdshot.R
@@ -15,8 +15,15 @@
 #'
 #' @examples
 #' if (interactive()) {
+#'   # rmdshot("rmarkdown_file.Rmd", "snapshot.png")
+#'
+#'   # R Markdown file
 #'   input_file <- system.file("examples/knitr-minimal.Rmd", package = "knitr")
 #'   rmdshot(input_file, "minimal_rmd.png")
+#'
+#'   # Shiny R Markdown file
+#'   input_file <- system.file("examples/shiny.Rmd", package = "webshot")
+#'   rmdshot(input_file, "shiny_rmd.png", delay = 5)
 #' }
 #'
 #' @export

--- a/R/rmdshot.R
+++ b/R/rmdshot.R
@@ -21,7 +21,7 @@
 #'
 #' @export
 rmdshot <- function(doc, file = "webshot.png", ..., delay = NULL, rmd_args = list(),
-                    port = getOption("shiny.port"), envvars = callr::rcmd_safe_env()) {
+                    port = getOption("shiny.port"), envvars = NULL) {
 
   runtime <- rmarkdown::yaml_front_matter(doc)$runtime
 
@@ -48,7 +48,7 @@ rmdshot_shiny <- function(doc, file, ..., rmd_args, port, envvars) {
   port <- available_port(port)
 
   # Run app in background with envvars
-  p <- callr::process$new(
+  p <- r_background_process(
     function(...) {
       rmarkdown::run(...)
     },
@@ -56,9 +56,8 @@ rmdshot_shiny <- function(doc, file, ..., rmd_args, port, envvars) {
       list(file = doc, shiny_args = list(port = port)),
       rmd_args
     ),
-    env = envvars
+    envvars = envvars
   )
-
   on.exit({
     p$kill()
   })

--- a/R/utils.R
+++ b/R/utils.R
@@ -15,6 +15,9 @@ phantom_run <- function(args, wait = TRUE) {
   )
 
   if (isTRUE(wait)) {
+    on.exit({
+      p$kill()
+    })
     while(p$is_alive()) {
       p$wait(200) # wait until min(c(time_ms, process ends))
       cat(p$read_error_lines()) # print the errors

--- a/R/utils.R
+++ b/R/utils.R
@@ -7,7 +7,21 @@ phantom_run <- function(args, wait = TRUE) {
   # Make sure args is a char vector
   args <- as.character(args)
 
-  system2(phantom_bin, args = args, wait = wait)
+  p <- callr::process$new(
+    phantom_bin,
+    args = args,
+    stdout = "|", stderr = "|",
+    supervise = TRUE
+  )
+
+  if (isTRUE(wait)) {
+    while(p$is_alive()) {
+      p$wait(200) # wait until min(c(time_ms, process ends))
+      cat(p$read_error_lines()) # print the errors
+      cat(p$read_output_lines()) # print the outputs
+    }
+  }
+  p$get_exit_status()
 }
 
 

--- a/R/webshot.R
+++ b/R/webshot.R
@@ -227,8 +227,8 @@ webshot <- function(
     # Workaround for SSL problem: https://github.com/wch/webshot/issues/51
     # https://stackoverflow.com/questions/22461345/casperjs-status-fail-on-a-webpage
     "--ignore-ssl-errors=true",
-    shQuote(system.file("webshot.js", package = "webshot")),
-    shQuote(jsonlite::toJSON(optsList))
+    system.file("webshot.js", package = "webshot"),
+    jsonlite::toJSON(optsList)
   )
 
   res <- phantom_run(args)

--- a/inst/examples/shiny.Rmd
+++ b/inst/examples/shiny.Rmd
@@ -1,0 +1,56 @@
+---
+title: "Shiny Example"
+author: "RStudio"
+date: "2/28/2018"
+output: html_document
+runtime: shiny
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = TRUE)
+```
+
+This R Markdown document is made interactive using Shiny. Unlike the more traditional workflow of creating static reports, you can now create documents that allow your readers to change the assumptions underlying your analysis and see the results immediately.
+
+To learn more, see [Interactive Documents](http://rmarkdown.rstudio.com/authoring_shiny.html).
+
+## Inputs and Outputs
+
+You can embed Shiny inputs and outputs in your document. Outputs are automatically updated whenever inputs change.  This demonstrates how a standard R plot can be made interactive by wrapping it in the Shiny `renderPlot` function. The `selectInput` and `sliderInput` functions create the input widgets used to drive the plot.
+
+```{r eruptions, echo=FALSE}
+inputPanel(
+  selectInput("n_breaks", label = "Number of bins:",
+              choices = c(10, 20, 35, 50), selected = 20),
+
+  sliderInput("bw_adjust", label = "Bandwidth adjustment:",
+              min = 0.2, max = 2, value = 1, step = 0.2)
+)
+
+renderPlot({
+  hist(faithful$eruptions, probability = TRUE, breaks = as.numeric(input$n_breaks),
+       xlab = "Duration (minutes)", main = "Geyser eruption duration")
+
+  dens <- density(faithful$eruptions, adjust = input$bw_adjust)
+  lines(dens, col = "blue")
+})
+```
+
+## Embedded Application
+
+It's also possible to embed an entire Shiny application within an R Markdown document using the `shinyAppDir` function. This example embeds a Shiny application located in another directory:
+
+```{r tabsets, echo=FALSE}
+shinyAppDir(
+  system.file("examples/06_tabsets", package = "shiny"),
+  options = list(
+    width = "100%", height = 550
+  )
+)
+```
+
+Note the use of the `height` parameter to determine how much vertical space the embedded application should occupy.
+
+You can also use the `shinyApp` function to define an application inline rather then in an external directory.
+
+In all of R code chunks above the `echo = FALSE` attribute is used. This is to prevent the R code within the chunk from rendering in the document alongside the Shiny components.

--- a/man/appshot.Rd
+++ b/man/appshot.Rd
@@ -2,19 +2,17 @@
 % Please edit documentation in R/appshot.R
 \name{appshot}
 \alias{appshot}
-\alias{appshot.shiny.appobj}
 \alias{appshot.character}
+\alias{appshot.shiny.appobj}
 \title{Take a screenshot of a Shiny app}
 \usage{
 appshot(app, file = "webshot.png", ..., port = getOption("shiny.port"),
   envvars = NULL)
 
-\method{appshot}{shiny.appobj}(app, file = "webshot.png", ...,
-  port = getOption("shiny.port"), envvars = NULL, env = NULL,
-  packages = NULL, save_file = tempfile(fileext = ".RData"),
-  env_file = tempfile(fileext = ".RData"))
-
 \method{appshot}{character}(app, file = "webshot.png", ...,
+  port = getOption("shiny.port"), envvars = NULL)
+
+\method{appshot}{shiny.appobj}(app, file = "webshot.png", ...,
   port = getOption("shiny.port"), envvars = NULL)
 }
 \arguments{
@@ -33,14 +31,6 @@ of the screenshot to the file name.}
 variables and values to set for the Shiny app's R process. These will be
 unset after the process exits. This can be used to pass configuration
 information to a Shiny app.}
-
-\item{env}{Environment to export all R objects for the Shiny app object.}
-
-\item{packages}{Character vector of R packages required for the Shiny app execution.  Defaults to use the currently attached packages.}
-
-\item{save_file}{File used to temporarily save the Shiny app object.}
-
-\item{env_file}{File used to temporarily save the Shiny app object server context to execute the app.}
 }
 \description{
 Take a screenshot of a Shiny app

--- a/man/appshot.Rd
+++ b/man/appshot.Rd
@@ -7,14 +7,13 @@
 \title{Take a screenshot of a Shiny app}
 \usage{
 appshot(app, file = "webshot.png", ..., port = getOption("shiny.port"),
-  envvars = callr::rcmd_safe_env())
+  envvars = NULL)
 
 \method{appshot}{character}(app, file = "webshot.png", ...,
-  port = getOption("shiny.port"), envvars = callr::rcmd_safe_env())
+  port = getOption("shiny.port"), envvars = NULL)
 
 \method{appshot}{shiny.appobj}(app, file = "webshot.png", ...,
-  port = getOption("shiny.port"), envvars = callr::rcmd_safe_env(),
-  webshot_timeout = 60)
+  port = getOption("shiny.port"), envvars = NULL, webshot_timeout = 60)
 }
 \arguments{
 \item{app}{A Shiny app object, or a string naming an app directory.}

--- a/man/appshot.Rd
+++ b/man/appshot.Rd
@@ -2,10 +2,20 @@
 % Please edit documentation in R/appshot.R
 \name{appshot}
 \alias{appshot}
+\alias{appshot.shiny.appobj}
+\alias{appshot.character}
 \title{Take a screenshot of a Shiny app}
 \usage{
 appshot(app, file = "webshot.png", ..., port = getOption("shiny.port"),
   envvars = NULL)
+
+\method{appshot}{shiny.appobj}(app, file = "webshot.png", ...,
+  port = getOption("shiny.port"), envvars = NULL, env = NULL,
+  packages = NULL, save_file = tempfile(fileext = ".RData"),
+  env_file = tempfile(fileext = ".RData"))
+
+\method{appshot}{character}(app, file = "webshot.png", ...,
+  port = getOption("shiny.port"), envvars = NULL)
 }
 \arguments{
 \item{app}{A Shiny app object, or a string naming an app directory.}

--- a/man/appshot.Rd
+++ b/man/appshot.Rd
@@ -36,7 +36,16 @@ information to a Shiny app.}
 \item{webshot_timeout}{The maximum number of seconds the phantom application is allowed to run before killing the process. (Only used for Shiny application objects)}
 }
 \description{
-The \code{appshot} performs a \code{\link{webshot}} using two different methods depending upon the object provided.  If a 'character' is provided (pointing to an app.R file or app directory) an isolated background R process is launched to run the Shiny application.  The current R process then captures the \code{\link{webshot}}.  When a Shiny application object is supplied to \code{appshot}, the Shiny application is run in the current R process and an isolated background R process is launched to capture a \code{\link{webshot}}.  Keeping the Shiny appliation in a different process is ideal, shiny application objects are launched in the current R process to avoid scoping errors.
+\code{appshot} performs a \code{\link{webshot}} using two different
+methods depending upon the object provided.  If a 'character' is provided
+(pointing to an app.R file or app directory) an isolated background R
+process is launched to run the Shiny application.  The current R process
+then captures the \code{\link{webshot}}.  When a Shiny application object
+is supplied to \code{appshot}, the Shiny application is run in the current
+R process and an isolated background R process is launched to capture a
+\code{\link{webshot}}.  Keeping the Shiny application in a different process
+is ideal, shiny application objects are launched in the current R process to
+avoid scoping errors.
 }
 \examples{
 if (interactive()) {

--- a/man/appshot.Rd
+++ b/man/appshot.Rd
@@ -33,7 +33,9 @@ variables and values to set for the Shiny app's R process. These will be
 unset after the process exits. This can be used to pass configuration
 information to a Shiny app.}
 
-\item{webshot_timeout}{The maximum number of seconds the phantom application is allowed to run before killing the process. (Only used for Shiny application objects)}
+\item{webshot_timeout}{The maximum number of seconds the phantom application
+is allowed to run before killing the process. If a delay argument is supplied (in
+\code{...}), the delay value is added to the timeout value.}
 }
 \description{
 \code{appshot} performs a \code{\link{webshot}} using two different

--- a/man/appshot.Rd
+++ b/man/appshot.Rd
@@ -7,13 +7,14 @@
 \title{Take a screenshot of a Shiny app}
 \usage{
 appshot(app, file = "webshot.png", ..., port = getOption("shiny.port"),
-  envvars = NULL)
+  envvars = callr::rcmd_safe_env())
 
 \method{appshot}{character}(app, file = "webshot.png", ...,
-  port = getOption("shiny.port"), envvars = NULL)
+  port = getOption("shiny.port"), envvars = callr::rcmd_safe_env())
 
 \method{appshot}{shiny.appobj}(app, file = "webshot.png", ...,
-  port = getOption("shiny.port"), envvars = NULL)
+  port = getOption("shiny.port"), envvars = callr::rcmd_safe_env(),
+  webshot_timeout = 60)
 }
 \arguments{
 \item{app}{A Shiny app object, or a string naming an app directory.}
@@ -31,9 +32,11 @@ of the screenshot to the file name.}
 variables and values to set for the Shiny app's R process. These will be
 unset after the process exits. This can be used to pass configuration
 information to a Shiny app.}
+
+\item{webshot_timeout}{The maximum number of seconds the phantom application is allowed to run before killing the process. (Only used for Shiny application objects)}
 }
 \description{
-Take a screenshot of a Shiny app
+The \code{appshot} performs a \code{\link{webshot}} using two different methods depending upon the object provided.  If a 'character' is provided (pointing to an app.R file or app directory) an isolated background R process is launched to run the Shiny application.  The current R process then captures the \code{\link{webshot}}.  When a Shiny application object is supplied to \code{appshot}, the Shiny application is run in the current R process and an isolated background R process is launched to capture a \code{\link{webshot}}.  Keeping the Shiny appliation in a different process is ideal, shiny application objects are launched in the current R process to avoid scoping errors.
 }
 \examples{
 if (interactive()) {

--- a/man/appshot.Rd
+++ b/man/appshot.Rd
@@ -23,6 +23,14 @@ of the screenshot to the file name.}
 variables and values to set for the Shiny app's R process. These will be
 unset after the process exits. This can be used to pass configuration
 information to a Shiny app.}
+
+\item{env}{Environment to export all R objects for the Shiny app object.}
+
+\item{packages}{Character vector of R packages required for the Shiny app execution.  Defaults to use the currently attached packages.}
+
+\item{save_file}{File used to temporarily save the Shiny app object.}
+
+\item{env_file}{File used to temporarily save the Shiny app object server context to execute the app.}
 }
 \description{
 Take a screenshot of a Shiny app
@@ -30,7 +38,13 @@ Take a screenshot of a Shiny app
 \examples{
 if (interactive()) {
   appdir <- system.file("examples", "01_hello", package="shiny")
+
+  # With a Shiny directory
   appshot(appdir, "01_hello.png")
+
+  # With a Shiny App object
+  shinyapp <- shiny::shinyAppDir(appdir)
+  appshot(shinyapp, "01_hello_app.png")
 }
 
 }

--- a/man/rmdshot.Rd
+++ b/man/rmdshot.Rd
@@ -5,7 +5,7 @@
 \title{Take a snapshot of an R Markdown document}
 \usage{
 rmdshot(doc, file = "webshot.png", ..., delay = NULL, rmd_args = list(),
-  port = getOption("shiny.port"), envvars = callr::rcmd_safe_env())
+  port = getOption("shiny.port"), envvars = NULL)
 }
 \arguments{
 \item{doc}{The path to a Rmd document.}
@@ -39,8 +39,15 @@ This function can handle both static Rmd documents and Rmd documents with
 }
 \examples{
 if (interactive()) {
+  # rmdshot("rmarkdown_file.Rmd", "snapshot.png")
+
+  # R Markdown file
   input_file <- system.file("examples/knitr-minimal.Rmd", package = "knitr")
   rmdshot(input_file, "minimal_rmd.png")
+
+  # Shiny R Markdown file
+  input_file <- system.file("examples/shiny.Rmd", package = "webshot")
+  rmdshot(input_file, "shiny_rmd.png", delay = 5)
 }
 
 }

--- a/man/rmdshot.Rd
+++ b/man/rmdshot.Rd
@@ -5,7 +5,7 @@
 \title{Take a snapshot of an R Markdown document}
 \usage{
 rmdshot(doc, file = "webshot.png", ..., delay = NULL, rmd_args = list(),
-  port = getOption("shiny.port"), envvars = NULL)
+  port = getOption("shiny.port"), envvars = callr::rcmd_safe_env())
 }
 \arguments{
 \item{doc}{The path to a Rmd document.}
@@ -39,7 +39,8 @@ This function can handle both static Rmd documents and Rmd documents with
 }
 \examples{
 if (interactive()) {
-  rmdshot("doc.rmd", "doc.png")
+  input_file <- system.file("examples/knitr-minimal.Rmd", package = "knitr")
+  rmdshot(input_file, "minimal_rmd.png")
 }
 
 }


### PR DESCRIPTION
Adds an appshot method for shiny app objects.  

* Saves all elements in the same environment as the server function of the app. 
* Saves all currently attached packages.  
* In a separate process, 
  * Loads the environment, app, and packages. 
  * Run the app
* Take a screenshot
