### PR TITLE
Add support to specify casper options to fix #60

### DIFF
--- a/R/webshot.R
+++ b/R/webshot.R
@@ -48,8 +48,8 @@
 #'   This is experimental and likely to change!
 #' @param debug Print out debugging messages from PhantomJS and CasperJS. This can help to
 #'   diagnose problems.
-#' @param options An optional list containing Casper options. See the Casper API
-#'   (\url{http://docs.casperjs.org/en/latest/modules/casper.html#index-1}).
+#' @param useragent The User-Agent header used to request the URL. Changing the
+#'   User-Agent can mitigate rendering issues for some websites.
 #'
 #' @examples
 #' if (interactive()) {
@@ -114,11 +114,8 @@
 #' webshot(
 #'   "https://www.rstudio.com/products/rstudio/download/",
 #'   "rstudio.png",
-#'   options = list(
-#'     pageSettings = list(
-#'       userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X)"
-#'     )
-#'   ))
+#'   useragent = "Mozilla/5.0 (Macintosh; Intel Mac OS X)"
+#' )
 #'
 #' # See more examples in the package vignette
 # vignette("intro", package = "webshot")
@@ -138,7 +135,7 @@ webshot <- function(
   zoom = 1,
   eval = NULL,
   debug = FALSE,
-  options = NULL
+  useragent = NULL
 ) {
 
   if (is.null(url)) {
@@ -235,7 +232,10 @@ webshot <- function(
   if (!is.null(delay)) optsList$delay <- delay
   if (!is.null(zoom)) optsList$zoom <- zoom
   if (!is.null(eval)) optsList$eval <- eval
-  if (!is.null(options)) optsList$options <- jsonlite::toJSON(options, auto_unbox = TRUE)
+  if (!is.null(useragent)) optsList$options <- jsonlite::toJSON(
+    list(pageSettings = list(userAgent = useragent)),
+    auto_unbox = TRUE
+  )
   optsList$debug <- debug
 
   args <- list(

--- a/R/webshot.R
+++ b/R/webshot.R
@@ -48,6 +48,8 @@
 #'   This is experimental and likely to change!
 #' @param debug Print out debugging messages from PhantomJS and CasperJS. This can help to
 #'   diagnose problems.
+#' @param options An optional list containing Casper options. See the Casper API
+#'   (\url{http://docs.casperjs.org/en/latest/modules/casper.html#index-1}).
 #'
 #' @examples
 #' if (interactive()) {
@@ -108,6 +110,16 @@
 #'  resize("75%") %>%
 #'  shrink()
 #'
+#' # Requests can change the User-Agent header
+#' webshot(
+#'   "https://www.rstudio.com/products/rstudio/download/",
+#'   "rstudio.png",
+#'   options = list(
+#'     pageSettings = list(
+#'       userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X)"
+#'     )
+#'   ))
+#'
 #' # See more examples in the package vignette
 # vignette("intro", package = "webshot")
 #' }
@@ -125,7 +137,8 @@ webshot <- function(
   delay = 0.2,
   zoom = 1,
   eval = NULL,
-  debug = FALSE
+  debug = FALSE,
+  options = NULL
 ) {
 
   if (is.null(url)) {
@@ -149,7 +162,8 @@ webshot <- function(
     delay = delay,
     zoom = zoom,
     eval = eval,
-    debug = debug
+    debug = debug,
+    options = options
   )
   arg_length <- vapply(arg_list, length, numeric(1))
   max_arg_length <- max(arg_length)
@@ -221,6 +235,7 @@ webshot <- function(
   if (!is.null(delay)) optsList$delay <- delay
   if (!is.null(zoom)) optsList$zoom <- zoom
   if (!is.null(eval)) optsList$eval <- eval
+  if (!is.null(options)) optsList$options <- jsonlite::toJSON(options, auto_unbox = TRUE)
   optsList$debug <- debug
 
   args <- list(

--- a/inst/webshot.js
+++ b/inst/webshot.js
@@ -41,6 +41,10 @@ var optsList = JSON.parse(args[1]);
 
 // Options passed to CasperJS
 var casperOpts = {};
+if (optsList[0].options) {
+  casperOpts = JSON.parse(optsList[0].options);
+}
+
 // `debug` is a special option. The value from the first element in the
 // optsList array is applied globally.
 if (optsList[0].debug) {

--- a/man/webshot.Rd
+++ b/man/webshot.Rd
@@ -6,7 +6,7 @@
 \usage{
 webshot(url = NULL, file = "webshot.png", vwidth = 992, vheight = 744,
   cliprect = NULL, selector = NULL, expand = NULL, delay = 0.2,
-  zoom = 1, eval = NULL, debug = FALSE)
+  zoom = 1, eval = NULL, debug = FALSE, options = NULL)
 }
 \arguments{
 \item{url}{A vector of URLs to visit.}
@@ -67,6 +67,9 @@ This is experimental and likely to change!}
 
 \item{debug}{Print out debugging messages from PhantomJS and CasperJS. This can help to
 diagnose problems.}
+
+\item{options}{An optional list containing Casper options. See the Casper API
+(\url{http://docs.casperjs.org/en/latest/modules/casper.html#index-1}).}
 }
 \description{
 Take a screenshot of a URL
@@ -129,6 +132,16 @@ webshot("http://www.reddit.com/", "reddit-input.png",
 webshot("https://www.r-project.org/", "r-small.png") \%>\%
  resize("75\%") \%>\%
  shrink()
+
+# Requests can change the User-Agent header
+webshot(
+  "https://www.rstudio.com/products/rstudio/download/",
+  "rstudio.png",
+  options = list(
+    pageSettings = list(
+      userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X)"
+    )
+  ))
 
 # See more examples in the package vignette
 }

--- a/man/webshot.Rd
+++ b/man/webshot.Rd
@@ -6,7 +6,7 @@
 \usage{
 webshot(url = NULL, file = "webshot.png", vwidth = 992, vheight = 744,
   cliprect = NULL, selector = NULL, expand = NULL, delay = 0.2,
-  zoom = 1, eval = NULL, debug = FALSE, options = NULL)
+  zoom = 1, eval = NULL, debug = FALSE, useragent = NULL)
 }
 \arguments{
 \item{url}{A vector of URLs to visit.}
@@ -68,8 +68,8 @@ This is experimental and likely to change!}
 \item{debug}{Print out debugging messages from PhantomJS and CasperJS. This can help to
 diagnose problems.}
 
-\item{options}{An optional list containing Casper options. See the Casper API
-(\url{http://docs.casperjs.org/en/latest/modules/casper.html#index-1}).}
+\item{useragent}{The User-Agent header used to request the URL. Changing the
+User-Agent can mitigate rendering issues for some websites.}
 }
 \description{
 Take a screenshot of a URL
@@ -137,11 +137,8 @@ webshot("https://www.r-project.org/", "r-small.png") \%>\%
 webshot(
   "https://www.rstudio.com/products/rstudio/download/",
   "rstudio.png",
-  options = list(
-    pageSettings = list(
-      userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X)"
-    )
-  ))
+  useragent = "Mozilla/5.0 (Macintosh; Intel Mac OS X)"
+)
 
 # See more examples in the package vignette
 }


### PR DESCRIPTION
See #60. This PR adds support for `options` to allow specifying additional options to 'casper' initialization since the `eval` parameter happens to trigger after the page is fetched.

Usage:

```r
webshot::webshot(
    "https://www.rstudio.com/products/rstudio/download/",
    options = list(pageSettings = list(userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X)")))
```