### PR TITLE
Fix phantom installation logic

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: webshot
 Title: Take Screenshots of Web Pages
-Version: 0.5.2
+Version: 0.5.2.9000
 Authors@R: c(
     person("Winston", "Chang", email = "winston@rstudio.com", role = c("aut", "cre")),
     person("Yihui", "Xie", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+webshot 0.5.2.9000
+=============
+
+* Fixed logic in `install_phantomjs()` when `force=TRUE` is used. ([#89](https://github.com/wch/webshot/pull/89))
+
 webshot 0.5.2
 =============
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -141,7 +141,7 @@ install_phantomjs <- function(version = '2.1.1',
     baseURL = 'https://github.com/wch/webshot/releases/download/v0.3.1/',
     force = FALSE) {
 
-  if (is_phantomjs_version_latest(version) && !force) {
+  if (!force && is_phantomjs_version_latest(version)) {
       message('It seems that the version of `phantomjs` installed is ',
               'greater than or equal to the requested version.',
               'To install the requested version or downgrade to another version, ',


### PR DESCRIPTION
With `install_phantomjs(force=TRUE)`, if calling `phantomjs --version` results in an error, then it would fail to install a new version of phantomjs. This fixes the logic so that if `force` is TRUE, then it won't check the old version.