### PR TITLE
Install phantomjs 2.5.0-beta on Windows

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ SystemRequirements: PhantomJS (http://phantomjs.org) for taking screenshots,
     ImageMagick (http://www.imagemagick.org) or GraphicsMagick
     (http://www.graphicsmagick.org) and OptiPNG (http://optipng.sourceforge.net)
     for manipulating images.
-RoxygenNote: 6.1.1
+RoxygenNote: 7.1.1
 Encoding: UTF-8
 URL: https://github.com/wch/webshot/
 BugReports: https://github.com/wch/webshot/issues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: webshot
 Title: Take Screenshots of Web Pages
-Version: 0.5.2.9000
+Version: 0.5.2.9001
 Authors@R: c(
     person("Winston", "Chang", email = "winston@rstudio.com", role = c("aut", "cre")),
     person("Yihui", "Xie", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 webshot 0.5.2.9000
 =============
 
+* On Windows, `install_phantomjs()` now installs version 2.5.0-beta2 by default, due to some font rendering issues with version 2.1.1. (#102)
+
 * Fixed logic in `install_phantomjs()` when `force=TRUE` is used. ([#89](https://github.com/wch/webshot/pull/89))
 
 webshot 0.5.2

--- a/R/utils.R
+++ b/R/utils.R
@@ -117,31 +117,31 @@ is_phantomjs_version_latest <- function(requested_version) {
 #' directory in which \pkg{webshot} can look for the PhantomJS executable.
 #'
 #' @details This function was designed primarily to help Windows users since it
-#' is cumbersome to modify the \code{PATH} variable. Mac OS X users may install
-#' PhantomJS via Homebrew. If you download the package from the PhantomJS
-#' website instead, please make sure the executable can be found via the
-#' \code{PATH} variable.
+#'   is cumbersome to modify the \code{PATH} variable. Mac OS X users may
+#'   install PhantomJS via Homebrew. If you download the package from the
+#'   PhantomJS website instead, please make sure the executable can be found via
+#'   the \code{PATH} variable.
 #'
-#' On Windows, the directory specified by the environment variable
-#' \code{APPDATA} is used to store \file{phantomjs.exe}. On OS X, the directory
-#' \file{~/Library/Application Support} is used. On other platforms (such as
-#' Linux), the directory \file{~/bin} is used. If these directories are not
-#' writable, the directory \file{PhantomJS} under the installation directory of
-#' the \pkg{webshot} package will be tried. If this directory still fails, you
-#' will have to install PhantomJS by yourself.
+#'   On Windows, the directory specified by the environment variable
+#'   \code{APPDATA} is used to store \file{phantomjs.exe}. On OS X, the
+#'   directory \file{~/Library/Application Support} is used. On other platforms
+#'   (such as Linux), the directory \file{~/bin} is used. If these directories
+#'   are not writable, the directory \file{PhantomJS} under the installation
+#'   directory of the \pkg{webshot} package will be tried. If this directory
+#'   still fails, you will have to install PhantomJS by yourself.
 #'
-#' If PhantomJS is not already installed on the computer, this function will
-#' attempt to install it. However, if the version of PhantomJS installed is
-#' greater than or equal to the requested version, this function will not
-#' perform the installation procedure again unless the \code{force} parameter is
-#' set to \code{TRUE}. As a result, this function may also be used to reinstall
-#' or downgrade the version of PhantomJS found.
+#'   If PhantomJS is not already installed on the computer, this function will
+#'   attempt to install it. However, if the version of PhantomJS installed is
+#'   greater than or equal to the requested version, this function will not
+#'   perform the installation procedure again unless the \code{force} parameter
+#'   is set to \code{TRUE}. As a result, this function may also be used to
+#'   reinstall or downgrade the version of PhantomJS found.
 #'
 #' @param version The version number of PhantomJS. If the value is "auto", then
 #'   on Mac and Linux, it will download version 2.1.1, and on Windows, it will
-#'   download 2.5.0-beta2. This is because 2.1.1 on Windows has some font
-#'   rendering issues that are fixed by 2.5.0-beta2, but on other platforms,
-#'   2.5.0-beta2 does not install and run reliably.
+#'   download 2.5.0-beta. This is because 2.1.1 on Windows has some font
+#'   rendering issues that are fixed by 2.5.0-beta, but on other platforms,
+#'   2.5.0-beta does not install and run reliably.
 #' @param baseURL The base URL for the location of PhantomJS binaries for
 #'   download. If the default download site is unavailable, you may specify an
 #'   alternative mirror, such as
@@ -157,7 +157,7 @@ install_phantomjs <- function(version = 'auto',
 
   if (version == "auto") {
     if (is_windows()) {
-      version <- "2.5.0-beta2"
+      version <- "2.5.0-beta"
     } else {
       version <- "2.1.1"
     }

--- a/R/utils.R
+++ b/R/utils.R
@@ -95,6 +95,17 @@ is_phantomjs_version_latest <- function(requested_version) {
   # Obtain the installed version
   installed_phantomjs_version <- phantomjs_version()
 
+  # For versions 2.5.0-beta and 2.5.0-beta2, phantomjs reports its version to be
+  # "2.5.0-development".
+  #
+  # However, for the requested version, we have the names "2.5.0-beta" and
+  # "2.5.0-beta2".
+  #
+  # For simplicity, we'll just remove the "-development" or "-beta" or "-beta2"
+  # so they all map to "2.5.0".
+  installed_phantomjs_version <- sub("-development", "", installed_phantomjs_version)
+  requested_version           <- sub("-beta.*",      "", requested_version)
+
   # Check if the installed version is latest compared to requested version.
   as.package_version(installed_phantomjs_version) >= requested_version
 }
@@ -105,9 +116,8 @@ is_phantomjs_version_latest <- function(requested_version) {
 #' Download the zip package, unzip it, and copy the executable to a system
 #' directory in which \pkg{webshot} can look for the PhantomJS executable.
 #'
-#' @details
-#' This function was designed primarily to help Windows users since it is
-#' cumbersome to modify the \code{PATH} variable. Mac OS X users may install
+#' @details This function was designed primarily to help Windows users since it
+#' is cumbersome to modify the \code{PATH} variable. Mac OS X users may install
 #' PhantomJS via Homebrew. If you download the package from the PhantomJS
 #' website instead, please make sure the executable can be found via the
 #' \code{PATH} variable.
@@ -124,22 +134,34 @@ is_phantomjs_version_latest <- function(requested_version) {
 #' attempt to install it. However, if the version of PhantomJS installed is
 #' greater than or equal to the requested version, this function will not
 #' perform the installation procedure again unless the \code{force} parameter is
-#' set to \code{TRUE}. As a result, this function may also be used to reinstall or
-#' downgrade the version of PhantomJS found.
+#' set to \code{TRUE}. As a result, this function may also be used to reinstall
+#' or downgrade the version of PhantomJS found.
 #'
-#' @param version The version number of PhantomJS.
+#' @param version The version number of PhantomJS. If the value is "auto", then
+#'   on Mac and Linux, it will download version 2.1.1, and on Windows, it will
+#'   download 2.5.0-beta2. This is because 2.1.1 on Windows has some font
+#'   rendering issues that are fixed by 2.5.0-beta2, but on other platforms,
+#'   2.5.0-beta2 does not install and run reliably.
 #' @param baseURL The base URL for the location of PhantomJS binaries for
 #'   download. If the default download site is unavailable, you may specify an
 #'   alternative mirror, such as
 #'   \code{"https://bitbucket.org/ariya/phantomjs/downloads/"}.
-#' @param force Install PhantomJS even if the version installed is the
-#'   latest or if the requested version is older. This is useful to reinstall
-#'   or downgrade the version of PhantomJS.
+#' @param force Install PhantomJS even if the version installed is the latest or
+#'   if the requested version is older. This is useful to reinstall or downgrade
+#'   the version of PhantomJS.
 #' @return \code{NULL} (the executable is written to a system directory).
 #' @export
-install_phantomjs <- function(version = '2.1.1',
+install_phantomjs <- function(version = 'auto',
     baseURL = 'https://github.com/wch/webshot/releases/download/v0.3.1/',
     force = FALSE) {
+
+  if (version == "auto") {
+    if (is_windows()) {
+      version <- "2.5.0-beta2"
+    } else {
+      version <- "2.1.1"
+    }
+  }
 
   if (!force && is_phantomjs_version_latest(version)) {
       message('It seems that the version of `phantomjs` installed is ',

--- a/man/appshot.Rd
+++ b/man/appshot.Rd
@@ -6,15 +6,30 @@
 \alias{appshot.shiny.appobj}
 \title{Take a screenshot of a Shiny app}
 \usage{
-appshot(app, file = "webshot.png", ..., port = getOption("shiny.port"),
-  envvars = NULL)
+appshot(
+  app,
+  file = "webshot.png",
+  ...,
+  port = getOption("shiny.port"),
+  envvars = NULL
+)
 
-\method{appshot}{character}(app, file = "webshot.png", ...,
-  port = getOption("shiny.port"), envvars = NULL)
+\method{appshot}{character}(
+  app,
+  file = "webshot.png",
+  ...,
+  port = getOption("shiny.port"),
+  envvars = NULL
+)
 
-\method{appshot}{shiny.appobj}(app, file = "webshot.png", ...,
-  port = getOption("shiny.port"), envvars = NULL,
-  webshot_timeout = 60)
+\method{appshot}{shiny.appobj}(
+  app,
+  file = "webshot.png",
+  ...,
+  port = getOption("shiny.port"),
+  envvars = NULL,
+  webshot_timeout = 60
+)
 }
 \arguments{
 \item{app}{A Shiny app object, or a string naming an app directory.}

--- a/man/install_phantomjs.Rd
+++ b/man/install_phantomjs.Rd
@@ -13,9 +13,9 @@ install_phantomjs(
 \arguments{
 \item{version}{The version number of PhantomJS. If the value is "auto", then
 on Mac and Linux, it will download version 2.1.1, and on Windows, it will
-download 2.5.0-beta2. This is because 2.1.1 on Windows has some font
-rendering issues that are fixed by 2.5.0-beta2, but on other platforms,
-2.5.0-beta2 does not install and run reliably.}
+download 2.5.0-beta. This is because 2.1.1 on Windows has some font
+rendering issues that are fixed by 2.5.0-beta, but on other platforms,
+2.5.0-beta does not install and run reliably.}
 
 \item{baseURL}{The base URL for the location of PhantomJS binaries for
 download. If the default download site is unavailable, you may specify an
@@ -35,23 +35,23 @@ directory in which \pkg{webshot} can look for the PhantomJS executable.
 }
 \details{
 This function was designed primarily to help Windows users since it
-is cumbersome to modify the \code{PATH} variable. Mac OS X users may install
-PhantomJS via Homebrew. If you download the package from the PhantomJS
-website instead, please make sure the executable can be found via the
-\code{PATH} variable.
+  is cumbersome to modify the \code{PATH} variable. Mac OS X users may
+  install PhantomJS via Homebrew. If you download the package from the
+  PhantomJS website instead, please make sure the executable can be found via
+  the \code{PATH} variable.
 
-On Windows, the directory specified by the environment variable
-\code{APPDATA} is used to store \file{phantomjs.exe}. On OS X, the directory
-\file{~/Library/Application Support} is used. On other platforms (such as
-Linux), the directory \file{~/bin} is used. If these directories are not
-writable, the directory \file{PhantomJS} under the installation directory of
-the \pkg{webshot} package will be tried. If this directory still fails, you
-will have to install PhantomJS by yourself.
+  On Windows, the directory specified by the environment variable
+  \code{APPDATA} is used to store \file{phantomjs.exe}. On OS X, the
+  directory \file{~/Library/Application Support} is used. On other platforms
+  (such as Linux), the directory \file{~/bin} is used. If these directories
+  are not writable, the directory \file{PhantomJS} under the installation
+  directory of the \pkg{webshot} package will be tried. If this directory
+  still fails, you will have to install PhantomJS by yourself.
 
-If PhantomJS is not already installed on the computer, this function will
-attempt to install it. However, if the version of PhantomJS installed is
-greater than or equal to the requested version, this function will not
-perform the installation procedure again unless the \code{force} parameter is
-set to \code{TRUE}. As a result, this function may also be used to reinstall
-or downgrade the version of PhantomJS found.
+  If PhantomJS is not already installed on the computer, this function will
+  attempt to install it. However, if the version of PhantomJS installed is
+  greater than or equal to the requested version, this function will not
+  perform the installation procedure again unless the \code{force} parameter
+  is set to \code{TRUE}. As a result, this function may also be used to
+  reinstall or downgrade the version of PhantomJS found.
 }

--- a/man/install_phantomjs.Rd
+++ b/man/install_phantomjs.Rd
@@ -4,21 +4,27 @@
 \alias{install_phantomjs}
 \title{Install PhantomJS}
 \usage{
-install_phantomjs(version = "2.1.1",
+install_phantomjs(
+  version = "auto",
   baseURL = "https://github.com/wch/webshot/releases/download/v0.3.1/",
-  force = FALSE)
+  force = FALSE
+)
 }
 \arguments{
-\item{version}{The version number of PhantomJS.}
+\item{version}{The version number of PhantomJS. If the value is "auto", then
+on Mac and Linux, it will download version 2.1.1, and on Windows, it will
+download 2.5.0-beta2. This is because 2.1.1 on Windows has some font
+rendering issues that are fixed by 2.5.0-beta2, but on other platforms,
+2.5.0-beta2 does not install and run reliably.}
 
 \item{baseURL}{The base URL for the location of PhantomJS binaries for
 download. If the default download site is unavailable, you may specify an
 alternative mirror, such as
 \code{"https://bitbucket.org/ariya/phantomjs/downloads/"}.}
 
-\item{force}{Install PhantomJS even if the version installed is the
-latest or if the requested version is older. This is useful to reinstall
-or downgrade the version of PhantomJS.}
+\item{force}{Install PhantomJS even if the version installed is the latest or
+if the requested version is older. This is useful to reinstall or downgrade
+the version of PhantomJS.}
 }
 \value{
 \code{NULL} (the executable is written to a system directory).
@@ -28,8 +34,8 @@ Download the zip package, unzip it, and copy the executable to a system
 directory in which \pkg{webshot} can look for the PhantomJS executable.
 }
 \details{
-This function was designed primarily to help Windows users since it is
-cumbersome to modify the \code{PATH} variable. Mac OS X users may install
+This function was designed primarily to help Windows users since it
+is cumbersome to modify the \code{PATH} variable. Mac OS X users may install
 PhantomJS via Homebrew. If you download the package from the PhantomJS
 website instead, please make sure the executable can be found via the
 \code{PATH} variable.
@@ -46,6 +52,6 @@ If PhantomJS is not already installed on the computer, this function will
 attempt to install it. However, if the version of PhantomJS installed is
 greater than or equal to the requested version, this function will not
 perform the installation procedure again unless the \code{force} parameter is
-set to \code{TRUE}. As a result, this function may also be used to reinstall or
-downgrade the version of PhantomJS found.
+set to \code{TRUE}. As a result, this function may also be used to reinstall
+or downgrade the version of PhantomJS found.
 }

--- a/man/reexports.Rd
+++ b/man/reexports.Rd
@@ -11,6 +11,6 @@ These objects are imported from other packages. Follow the links
 below to see their documentation.
 
 \describe{
-  \item{magrittr}{\code{\link[magrittr]{\%>\%}}}
+  \item{magrittr}{\code{\link[magrittr:pipe]{\%>\%}}}
 }}
 

--- a/man/rmdshot.Rd
+++ b/man/rmdshot.Rd
@@ -4,8 +4,15 @@
 \alias{rmdshot}
 \title{Take a snapshot of an R Markdown document}
 \usage{
-rmdshot(doc, file = "webshot.png", ..., delay = NULL,
-  rmd_args = list(), port = getOption("shiny.port"), envvars = NULL)
+rmdshot(
+  doc,
+  file = "webshot.png",
+  ...,
+  delay = NULL,
+  rmd_args = list(),
+  port = getOption("shiny.port"),
+  envvars = NULL
+)
 }
 \arguments{
 \item{doc}{The path to a Rmd document.}

--- a/man/webshot.Rd
+++ b/man/webshot.Rd
@@ -4,10 +4,20 @@
 \alias{webshot}
 \title{Take a screenshot of a URL}
 \usage{
-webshot(url = NULL, file = "webshot.png", vwidth = 992,
-  vheight = 744, cliprect = NULL, selector = NULL, expand = NULL,
-  delay = 0.2, zoom = 1, eval = NULL, debug = FALSE,
-  useragent = NULL)
+webshot(
+  url = NULL,
+  file = "webshot.png",
+  vwidth = 992,
+  vheight = 744,
+  cliprect = NULL,
+  selector = NULL,
+  expand = NULL,
+  delay = 0.2,
+  zoom = 1,
+  eval = NULL,
+  debug = FALSE,
+  useragent = NULL
+)
 }
 \arguments{
 \item{url}{A vector of URLs to visit.}
@@ -119,11 +129,11 @@ webshot("http://www.reddit.com/", "reddit-input.png",
     // Check the remember me box
     this.click('#rem-login-main');
     // Enter username and password
-    this.sendKeys('#login_login-main input[type=\\"text\\"]', 'my_username');
-    this.sendKeys('#login_login-main input[type=\\"password\\"]', 'password');
+    this.sendKeys('#login_login-main input[type=\"text\"]', 'my_username');
+    this.sendKeys('#login_login-main input[type=\"password\"]', 'password');
 
     // Now click in the search box. This results in a box expanding below
-    this.click('#search input[type=\\"text\\"]');
+    this.click('#search input[type=\"text\"]');
     // Wait 500ms
     this.wait(500);
   });"


### PR DESCRIPTION
Phantomjs 2.1.1 on Windows has some problems rendering certain fonts (e.g., many Font-Awesome icons, and some bold fonts), and using 2.5.0-beta fixes some of these issues. (Note that we tried 2.5.0-beta2 on Windows, and it did not work properly.)

This PR does not cause 2.5.0-beta to install on Mac and Linux. On Mac, running `phantomjs` simply crashes, and on Linux, it doesn't run on newer versions due to dynamic linking to an old version of libpng which is not present.