### PR TITLE
Revert #102 PhantomJS `version = "auto"` logic for windows

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: webshot
 Title: Take Screenshots of Web Pages
-Version: 0.5.2.9001
+Version: 0.5.2.9002
 Authors@R: c(
     person("Winston", "Chang", email = "winston@rstudio.com", role = c("aut", "cre")),
     person("Yihui", "Xie", role = "ctb"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,6 @@
 webshot 0.5.2.9000
 =============
 
-* On Windows, `install_phantomjs()` now installs version 2.5.0-beta by default, due to some font rendering issues with version 2.1.1. (#102)
-
 * Fixed logic in `install_phantomjs()` when `force=TRUE` is used. ([#89](https://github.com/wch/webshot/pull/89))
 
 webshot 0.5.2

--- a/R/utils.R
+++ b/R/utils.R
@@ -137,11 +137,7 @@ is_phantomjs_version_latest <- function(requested_version) {
 #'   is set to \code{TRUE}. As a result, this function may also be used to
 #'   reinstall or downgrade the version of PhantomJS found.
 #'
-#' @param version The version number of PhantomJS. If the value is "auto", then
-#'   on Mac and Linux, it will download version 2.1.1, and on Windows, it will
-#'   download 2.5.0-beta. This is because 2.1.1 on Windows has some font
-#'   rendering issues that are fixed by 2.5.0-beta, but on other platforms,
-#'   2.5.0-beta does not install and run reliably.
+#' @param version The version number of PhantomJS.
 #' @param baseURL The base URL for the location of PhantomJS binaries for
 #'   download. If the default download site is unavailable, you may specify an
 #'   alternative mirror, such as
@@ -151,17 +147,9 @@ is_phantomjs_version_latest <- function(requested_version) {
 #'   the version of PhantomJS.
 #' @return \code{NULL} (the executable is written to a system directory).
 #' @export
-install_phantomjs <- function(version = 'auto',
+install_phantomjs <- function(version = '2.1.1',
     baseURL = 'https://github.com/wch/webshot/releases/download/v0.3.1/',
     force = FALSE) {
-
-  if (version == "auto") {
-    if (is_windows()) {
-      version <- "2.5.0-beta"
-    } else {
-      version <- "2.1.1"
-    }
-  }
 
   if (!force && is_phantomjs_version_latest(version)) {
       message('It seems that the version of `phantomjs` installed is ',

--- a/man/install_phantomjs.Rd
+++ b/man/install_phantomjs.Rd
@@ -5,17 +5,13 @@
 \title{Install PhantomJS}
 \usage{
 install_phantomjs(
-  version = "auto",
+  version = "2.1.1",
   baseURL = "https://github.com/wch/webshot/releases/download/v0.3.1/",
   force = FALSE
 )
 }
 \arguments{
-\item{version}{The version number of PhantomJS. If the value is "auto", then
-on Mac and Linux, it will download version 2.1.1, and on Windows, it will
-download 2.5.0-beta. This is because 2.1.1 on Windows has some font
-rendering issues that are fixed by 2.5.0-beta, but on other platforms,
-2.5.0-beta does not install and run reliably.}
+\item{version}{The version number of PhantomJS.}
 
 \item{baseURL}{The base URL for the location of PhantomJS binaries for
 download. If the default download site is unavailable, you may specify an


### PR DESCRIPTION
Related: https://github.com/wch/webshot/pull/102/files
Related: https://github.com/rstudio/fontawesome/pull/61

* Kept the logic within `is_phantomjs_version_latest()` to help trim up the trailing "beta" or "development" in the version.