### PR TITLE
Fix windows file url handling

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@ webshot 0.5.2.9000
 
 * Fixed logic in `install_phantomjs()` when `force=TRUE` is used. ([#89](https://github.com/wch/webshot/pull/89))
 
+* Fixed handling of `file://` URLs in Windows, when the URL contains a drive letter and colon, such as `"file://localhost/C:\\msys64"`. (#110, Thanks to Tomas Kalibera)
+
 webshot 0.5.2
 =============
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -364,8 +364,10 @@ fix_windows_url <- function(url) {
   fix_one <- function(x) {
     # If it's a "c:/path/file.html" path, or contains any backslashs, like
     # "c:\path", "\\path\\file.html", or "/path\\file.html", we need to fix it
-    # up.
-    if (grepl("^[a-zA-Z]:/", x) || grepl("\\", x, fixed = TRUE)) {
+    # up. However, we need to leave paths that are already URLs alone.
+    if (grepl("^[a-zA-Z]:/", x) ||
+        (!grepl(":", x, fixed = TRUE) && grepl("\\", x, fixed = TRUE)))
+    {
       paste0("file:///", normalizePath(x, winslash = "/"))
     } else {
       x


### PR DESCRIPTION
This change makes `fix_windows_url` handle URLs like `"file://localhost/C:\\msys64"`, with a protocol and backslashes.